### PR TITLE
Fix email send and request keyboard

### DIFF
--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -24,7 +24,7 @@ async def start_request(message: types.Message, state: FSMContext):
         resize_keyboard=True
     )
 
-    await message.answer("Введите ФИО владельца:", reply_markup=back_menu())
+    await message.answer("Введите ФИО владельца:", reply_markup=kb)
 
 # 2️⃣ ФИО
 @router.message(RequestStates.request_name)

--- a/bot_alista/services/email.py
+++ b/bot_alista/services/email.py
@@ -50,4 +50,3 @@ def send_email(
         print(f"❌ Ошибка отправки письма: {e}")
         return False
 
-        server.sendmail(EMAIL_LOGIN, EMAIL_TO, msg.as_string())


### PR DESCRIPTION
## Summary
- Correct request start handler to display only main-menu keyboard
- Clean up email utility by removing unreachable sendmail call

## Testing
- `python -m compileall .`
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_68945a6eadf4832ba41626f4add1ef8f