### PR TITLE
Fix request sending and optional report in bot

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -5,7 +5,7 @@ import asyncio
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 from states import CalculationStates
-from keyboards.navigation import back_menu
+from keyboards.navigation import back_menu, yes_no_menu
 from services.customs import calculate_customs, get_cbr_eur_rate
 from services.email import send_email
 from services.pdf_report import generate_calculation_pdf
@@ -181,11 +181,35 @@ async def run_calculation(state: FSMContext, message: types.Message):
     )
 
     await message.answer(text)
-    await message.answer("📧 Введите ваш e‑mail для получения PDF‑отчёта:", reply_markup=back_menu())
-    await state.set_state(CalculationStates.email_request)
+    await message.answer(
+        "📧 Хотите получить PDF‑отчёт на e‑mail?",
+        reply_markup=yes_no_menu(),
+    )
+    await state.set_state(CalculationStates.email_confirm)
 
 
-# 🔟 Получаем email и отправляем PDF
+# 🔟 Подтверждаем отправку PDF
+@router.message(CalculationStates.email_confirm)
+async def confirm_pdf(message: types.Message, state: FSMContext):
+    if await _check_exit(message, state):
+        return
+    if message.text == "Да":
+        await message.answer(
+            "Введите ваш e‑mail для получения PDF‑отчёта:",
+            reply_markup=back_menu(),
+        )
+        await state.set_state(CalculationStates.email_request)
+    elif message.text == "Нет":
+        await message.answer("Отчёт не будет отправлен.")
+        await reset_to_menu(message, state)
+    else:
+        await message.answer(
+            "Пожалуйста, выберите ответ: 'Да' или 'Нет'.",
+            reply_markup=yes_no_menu(),
+        )
+
+
+# 1️⃣1️⃣ Получаем email и отправляем PDF
 @router.message(CalculationStates.email_request)
 async def send_pdf_report_to_user(message: types.Message, state: FSMContext):
     if await _check_exit(message, state):

--- a/bot_alista/handlers/menu.py
+++ b/bot_alista/handlers/menu.py
@@ -2,14 +2,15 @@ from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from keyboards.main_menu import main_menu
-from utils.reset import reset_to_menu
 
 router = Router()
 
+
 @router.message(Command("start"))
 async def cmd_start(message: types.Message, state: FSMContext):
-    await reset_to_menu(message, state)
+    await state.clear()
     await message.answer(
         "Привет! Я бот по растаможке авто 🚗\nВыберите действие:",
-        reply_markup=main_menu()
+        reply_markup=main_menu(),
     )
+

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -5,6 +5,7 @@ from keyboards.navigation import back_menu
 from services.email import send_email
 from services.pdf_report import generate_request_pdf
 from utils.reset import reset_to_menu
+from config import EMAIL_TO
 
 import os
 import uuid
@@ -82,7 +83,7 @@ async def get_comment(message: types.Message, state: FSMContext):
     generate_request_pdf(data, pdf_path)
 
     # Отправляем на e-mail менеджера
-    if send_email("korol.artur.2002@yandex.ru", "Заявка на растаможку", email_body, pdf_path):
+    if send_email(EMAIL_TO, "Заявка на растаможку", email_body, pdf_path):
         await message.answer("✅ Заявка отправлена! Наш специалист свяжется с вами.", 
                              reply_markup=back_menu())
     else:

--- a/bot_alista/keyboards/navigation.py
+++ b/bot_alista/keyboards/navigation.py
@@ -5,3 +5,12 @@ def back_menu():
         [KeyboardButton(text="⬅ Назад"), KeyboardButton(text="🏠 Главное меню")]
     ]
     return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)
+
+
+def yes_no_menu() -> ReplyKeyboardMarkup:
+    """Keyboard with Yes/No options and main menu button."""
+    kb = [
+        [KeyboardButton(text="Да"), KeyboardButton(text="Нет")],
+        [KeyboardButton(text="🏠 Главное меню")]
+    ]
+    return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)

--- a/bot_alista/states.py
+++ b/bot_alista/states.py
@@ -9,6 +9,7 @@ class CalculationStates(StatesGroup):
     calc_year = State()
     calc_weight = State()
     manual_eur_rate = State()
+    email_confirm = State()
     email_request = State()
 
 # Состояния подачи заявки


### PR DESCRIPTION
## Summary
- Send application emails to configured manager address
- Let users choose to receive PDF report and collect email only on consent
- Prevent duplicate main menu message on `/start`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946d208488832b84175d7706e99053