### PR TITLE
Load configuration from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Telegram bot token
+BOT_TOKEN=
+
+# SMTP server configuration
+SMTP_SERVER=
+SMTP_PORT=465
+EMAIL_LOGIN=
+EMAIL_PASSWORD=
+
+# Recipient email address
+EMAIL_TO=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 bot_alista/bot.log
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# AlistaBot
+
+## Configuration
+
+The bot reads configuration from environment variables. Create a `.env` file using `.env.example` as a template and fill in your values:
+
+```
+cp .env.example .env
+# edit .env
+```
+
+Required variables:
+
+- `BOT_TOKEN` – Telegram bot token.
+- `SMTP_SERVER` – SMTP server host.
+- `SMTP_PORT` – SMTP port.
+- `EMAIL_LOGIN` – SMTP account username.
+- `EMAIL_PASSWORD` – SMTP account password.
+- `EMAIL_TO` – recipient email address.
+
+The application uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file. Install dependencies and run the bot:
+
+```
+pip install python-dotenv
+python bot_alista/main.py
+```
+
+For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.

--- a/bot_alista/config.py
+++ b/bot_alista/config.py
@@ -1,8 +1,14 @@
-TOKEN = "8318772952:AAGGMwcRSbbd42YuR-rkUkA53Qf6DHTQJTs"
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TOKEN = os.getenv("BOT_TOKEN")
 
 # Настройки для отправки email
-SMTP_SERVER = "smtp.yandex.ru"
-SMTP_PORT = 465
-EMAIL_LOGIN = "korol.artur.2002@yandex.ru"
-EMAIL_PASSWORD = "attqhdcqxfdkepcm"
-EMAIL_TO = "korol.artur.2002@yandex.ru"
+SMTP_SERVER = os.getenv("SMTP_SERVER")
+SMTP_PORT = int(os.getenv("SMTP_PORT", 465))
+EMAIL_LOGIN = os.getenv("EMAIL_LOGIN")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+EMAIL_TO = os.getenv("EMAIL_TO")


### PR DESCRIPTION
## Summary
- Switch configuration to read from environment variables with python-dotenv support
- Provide `.env.example` and documentation for required environment variables
- Document running the bot with environment-based configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install python-dotenv` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68946da1b9d4832b91ad6cd52a0a099b