### PR TITLE
Refactor customs calculation and validate tariff data

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -6,7 +6,7 @@ from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 from states import CalculationStates
 from keyboards.navigation import back_menu, yes_no_menu
-from services.customs import calculate_customs, get_cbr_eur_rate
+from services.customs import calculate_customs, get_cbr_eur_rate, fetch_tariffs
 from services.email import send_email
 from services.pdf_report import generate_calculation_pdf
 from aiogram.types import FSInputFile
@@ -154,6 +154,7 @@ async def run_calculation(state: FSMContext, message: types.Message):
     data = await state.get_data()
     engine = data.get("engine", 0)
     eur_rate = data.get("eur_rate")
+    tariffs = fetch_tariffs()
 
     result = calculate_customs(
         price_eur=data["price"],
@@ -163,6 +164,7 @@ async def run_calculation(state: FSMContext, message: types.Message):
         power_hp=data["power_hp"],
         weight_kg=data["weight"],
         eur_rate=eur_rate,
+        tariffs=tariffs,
     )
 
     # Сохраняем результат в состояние, чтобы использовать его при отправке PDF

--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -56,6 +56,7 @@ def calculate_customs(
     power_hp: float = 0,
     weight_kg: float = 0,
     eur_rate: float | None = None,
+    tariffs: dict | None = None,
 ) -> dict:
     """
     price_eur — цена авто в евро
@@ -65,12 +66,14 @@ def calculate_customs(
     power_hp — мощность в л.с.
     weight_kg — масса авто в кг
     eur_rate — курс евро (если None, будет попытка получить автоматически)
+    tariffs — словарь с тарифами (если None, будет получен автоматически)
     """
 
     current_year = datetime.now().year
     age = current_year - year
 
-    tariffs = fetch_tariffs()
+    if tariffs is None:
+        tariffs = fetch_tariffs()
     duty_tables = tariffs["duty"]
     under_3 = duty_tables.get("under_3", {"per_cc": 2.5, "price_percent": 0.48})
     rates_3_5 = duty_tables.get("3_5", [])


### PR DESCRIPTION
## Summary
- allow calculate_customs to accept external tariff data
- fetch tariffs once in handler and pass into calculation
- validate fetched customs tariff data and fall back to defaults on error

## Testing
- `pytest`
- `python -m py_compile bot_alista/services/customs.py bot_alista/handlers/calculate.py bot_alista/services/customs_rates.py`


------
https://chatgpt.com/codex/tasks/task_e_68947691cfdc832b8dbed3f1b34614d3