### PR TITLE
Fix Unicode PDF generation for Telegram bot

### DIFF
--- a/bot_alista/services/pdf_report.py
+++ b/bot_alista/services/pdf_report.py
@@ -3,15 +3,30 @@
 from fpdf import FPDF
 
 
+# Paths to system fonts that support Cyrillic characters. Using existing
+# DejaVu fonts avoids the need to ship binary font files with the project.
+FONT_REGULAR = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+FONT_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+
+
 class PDFReport(FPDF):
+    """FPDF subclass pre-configured with Unicode fonts."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Register DejaVu fonts once per document. These fonts support
+        # Cyrillic text which is required for the bot's PDF reports.
+        self.add_font("DejaVu", "", FONT_REGULAR, uni=True)
+        self.add_font("DejaVu", "B", FONT_BOLD, uni=True)
+
     def header(self):
-        self.set_font("Arial", "B", 14)
+        self.set_font("DejaVu", "B", 14)
         self.cell(0, 10, self.title, ln=True, align="C")
         self.ln(5)
 
     def footer(self):
         self.set_y(-15)
-        self.set_font("Arial", "I", 8)
+        self.set_font("DejaVu", "", 8)
         self.cell(0, 10, f"Стр. {self.page_no()}", align="C")
 
 
@@ -21,7 +36,7 @@ def generate_request_pdf(data: dict, filename: str):
     pdf.title = "Заявка на растаможку"
     pdf.add_page()
 
-    pdf.set_font("Arial", "", 12)
+    pdf.set_font("DejaVu", "", 12)
     pdf.cell(0, 8, f"ФИО: {data.get('name', '')}", ln=True)
     pdf.cell(0, 8, f"Авто: {data.get('car', '')}", ln=True)
     pdf.cell(0, 8, f"Контакты: {data.get('contact', '')}", ln=True)
@@ -37,7 +52,7 @@ def generate_calculation_pdf(result: dict, user_info: dict, filename: str):
     pdf.title = "Отчёт по расчёту растаможки"
     pdf.add_page()
 
-    pdf.set_font("Arial", "B", 12)
+    pdf.set_font("DejaVu", "B", 12)
     pdf.cell(0, 8, f"Тип авто: {user_info.get('car_type', '')}", ln=True)
     pdf.cell(0, 8, f"Год выпуска: {user_info.get('year', '')}", ln=True)
     pdf.cell(0, 8, f"Мощность: {user_info.get('power_hp', '')} л.с.", ln=True)
@@ -47,9 +62,9 @@ def generate_calculation_pdf(result: dict, user_info: dict, filename: str):
     pdf.ln(5)
 
     # Таблица расчёта
-    pdf.set_font("Arial", "B", 12)
+    pdf.set_font("DejaVu", "B", 12)
     pdf.cell(0, 10, "Результаты расчёта", ln=True)
-    pdf.set_font("Arial", "", 11)
+    pdf.set_font("DejaVu", "", 11)
 
     def add_row(name, value):
         pdf.cell(90, 8, name, border=1)


### PR DESCRIPTION
## Summary
- add DejaVu fonts to FPDF reports to support Cyrillic text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689808f7ecd8832baa4085ced8b3468b