### PR TITLE
Refactor tariff rate utilities and streamline customs calc

### DIFF
--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -81,7 +81,6 @@ def calculate_customs(
 
     duty = 0
     excise_rub = 0
-    utilization_fee = 0
 
     # Логика для ДВС
     if car_type.lower() in ["бензин", "дизель"]:
@@ -125,15 +124,15 @@ def calculate_customs(
         eur_rate = 100.0  # по умолчанию, будет заменён вручную
 
     utilization_fee = utilization_fee_rub / eur_rate
-    excise = excise_rub / eur_rate  # переводим акциз в евро
+    excise_eur = excise_rub / eur_rate  # переводим акциз в евро
 
     # НДС (20%)
-    vat = (price_eur + duty + excise + utilization_fee) * 0.20
+    vat = (price_eur + duty + excise_eur + utilization_fee) * 0.20
 
     # Сбор за оформление
     fee = tariffs.get("processing_fee", 5)
 
-    total_eur = duty + excise + vat + utilization_fee + fee
+    total_eur = duty + excise_eur + vat + utilization_fee + fee
     total_rub = total_eur * eur_rate
 
     return {
@@ -144,7 +143,7 @@ def calculate_customs(
         "age": age,
         "eur_rate": round(eur_rate, 2),
         "duty_eur": round(duty, 2),
-        "excise_eur": round(excise, 2),
+        "excise_eur": round(excise_eur, 2),
         "vat_eur": round(vat, 2),
         "util_eur": round(utilization_fee, 2),
         "fee_eur": fee,

--- a/bot_alista/services/customs_rates.py
+++ b/bot_alista/services/customs_rates.py
@@ -1,8 +1,17 @@
-import requests
-import xml.etree.ElementTree as ET
+"""Tariff rate retrieval with per-day caching.
+
+This module fetches tariff data from a remote endpoint and caches it for the
+current day.  The original implementation pulled in a couple of unused typing
+imports and did not group the imports in a clear manner.  Cleaning this up
+reduces noise and clarifies the external dependency on ``requests``.
+"""
+
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Tuple
+import xml.etree.ElementTree as ET
+from typing import Any, Dict
+
+import requests
 
 # Default fallback tariffs in case fetching fails
 DEFAULT_TARIFFS: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- streamline tariff rate helper by grouping imports and removing unused typing
- simplify customs calculation by dropping an unused variable and clarifying excise naming

## Testing
- `python -m py_compile bot_alista/services/customs_rates.py bot_alista/services/customs.py bot_alista/handlers/request.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b1a129244832b88fc730b6050f239