### PR TITLE
feat: add multi-currency customs calculator

### DIFF
--- a/bot_alista/services/rates.py
+++ b/bot_alista/services/rates.py
@@ -1,0 +1,50 @@
+"""Currency rates utilities with simple daily caching."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from functools import lru_cache
+from typing import Dict, Iterable
+
+import requests
+
+CBR_URL = "https://www.cbr-xml-daily.ru/daily_json.js"
+
+
+@lru_cache()
+def _fetch_daily(_: date) -> Dict[str, Dict[str, float]]:
+    """Fetch daily rates from the CBR public API.
+
+    The returned mapping is keyed by currency code and contains ``Value`` and
+    ``Nominal`` fields. ``date`` is part of the cache key but the API only
+    serves the latest rates which is sufficient for this project.
+    """
+    resp = requests.get(CBR_URL, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()["Valute"]
+    return {code: {"Value": float(v["Value"]), "Nominal": float(v["Nominal"])} for code, v in data.items()}
+
+
+def get_cached_rates(day: date, codes: Iterable[str]) -> Dict[str, float]:
+    """Return RUB rates for requested currency ``codes`` on ``day``.
+
+    Rates are expressed as RUB for one unit of foreign currency and cached per
+    day. Raises an exception if fetching fails or a currency is missing.
+    """
+    try:
+        all_rates = _fetch_daily(day)
+        rates: Dict[str, float] = {}
+        for code in codes:
+            info = all_rates[code]
+            rates[code] = round(info["Value"] / info["Nominal"], 6)
+        return rates
+    except Exception as exc:  # pragma: no cover - network related
+        logging.exception("Failed to fetch currency rates: %s", exc)
+        raise
+
+
+def currency_to_rub(amount: float, currency_code: str, day: date) -> float:
+    """Convert ``amount`` in ``currency_code`` to RUB for the given ``day``."""
+    rates = get_cached_rates(day, codes=[currency_code])
+    return round(amount * rates[currency_code], 2)

--- a/bot_alista/states.py
+++ b/bot_alista/states.py
@@ -3,12 +3,11 @@ from aiogram.fsm.state import State, StatesGroup
 # Состояния расчёта растаможки
 class CalculationStates(StatesGroup):
     calc_type = State()
+    calc_currency = State()
     calc_price = State()
     calc_engine = State()
     calc_power = State()
     calc_year = State()
-    calc_weight = State()
-    manual_eur_rate = State()
     email_confirm = State()
     email_request = State()
 

--- a/bot_alista/tariff/__init__.py
+++ b/bot_alista/tariff/__init__.py
@@ -1,0 +1,1 @@
+"""Tariff related helpers."""

--- a/bot_alista/tariff/util_fee.py
+++ b/bot_alista/tariff/util_fee.py
@@ -1,0 +1,39 @@
+"""Wrapper around core utilisation fee calculation."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Optional
+
+from tariff_engine import UTIL_CONFIG as _UTIL_CONFIG, calc_util_rub as _calc_util_rub
+
+
+def calc_util_rub(
+    *,
+    person_type: str,
+    usage: str,
+    engine_cc: int,
+    fuel: str,
+    vehicle_kind: str,
+    age_years: float,
+    date_decl: date,
+    avg_vehicle_cost_rub: Optional[float],
+    actual_costs_rub: Optional[float],
+    config: dict[str, Any] = _UTIL_CONFIG,
+) -> float:
+    """Public wrapper matching project naming conventions."""
+    return _calc_util_rub(
+        person_type=person_type,
+        usage_type=usage,
+        engine_cc=engine_cc,
+        fuel_type=fuel,
+        vehicle_kind=vehicle_kind,
+        age_years=age_years,
+        date_decl=date_decl,
+        avg_vehicle_cost_rub=avg_vehicle_cost_rub,
+        actual_costs_rub=actual_costs_rub,
+        config=config,
+    )
+
+
+UTIL_CONFIG = _UTIL_CONFIG


### PR DESCRIPTION
## Summary
- add currency selection flow with EUR/USD/JPY/CNY buttons
- compute customs fees using updated tariff engine and util fee helpers
- implement cached CBR rates and conversion utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b232fa248832ba81899f64a6ad52d