### PR TITLE
Handle missing CBR rate via manual input

### DIFF
--- a/bot_alista/services/rates.py
+++ b/bot_alista/services/rates.py
@@ -1,0 +1,26 @@
+"""Utilities for validating manual currency rates."""
+
+def validate_or_prompt_rate(text: str) -> float | None:
+    """Validate user-provided currency rate.
+
+    Parameters
+    ----------
+    text: str
+        Raw text input from user containing a currency rate. Commas are allowed
+        as decimal separators.
+
+    Returns
+    -------
+    float | None
+        Parsed float value if the input is a valid positive number, otherwise
+        ``None``.
+    """
+    if text is None:
+        return None
+    try:
+        rate = float(text.replace(",", ".").strip())
+        if rate <= 0:
+            return None
+        return rate
+    except (ValueError, AttributeError):
+        return None


### PR DESCRIPTION
## Summary
- validate manual currency rates via shared helper
- prompt for missing CBR rates and persist user-provided values

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2380aaf4832b86e61e5f9c353154