### PR TITLE
docs: clarify customs rates and util coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ python bot_alista/main.py
 
 The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.
 
+
+## Customs and Tariff Notes
+
+- Customs value can now be entered in EUR, USD, JPY or CNY. CBR daily rates are fetched by declaration date; if unavailable, the bot asks for manual rates.
+- Import duty minimal threshold is 0.44 EUR/cc; we convert it by the EUR CBR rate on the declaration date.
+- UTIL coefficients are configured in `bot_alista/tariff/util_fee.py` via the `UTIL_CONFIG` constant.
+


### PR DESCRIPTION
## Summary
- document support for EUR/USD/JPY/CNY customs values and CBR rate fallback
- note import duty threshold conversion by EUR CBR rate
- point to `UTIL_CONFIG` for editing UTIL coefficients

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b23a1a5d4832bb4a89e159f515d9b