### PR TITLE
Add CBR currency rate service with caching

### DIFF
--- a/bot_alista/services/rates.py
+++ b/bot_alista/services/rates.py
@@ -1,0 +1,196 @@
+"""Валютные курсы ЦБ РФ с кэшированием.
+
+Использует ежедневный XML‑файл ЦБ РФ и кэширует результаты на диске
+в формате JSON. Поддерживаются курсы EUR, USD, JPY и CNY.
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Dict, Iterable, Literal
+import json
+import time
+import xml.etree.ElementTree as ET
+
+import requests
+
+SUPPORTED_CODES: tuple[str, ...] = ("EUR", "USD", "JPY", "CNY")
+CBR_URL = "https://www.cbr.ru/scripts/XML_daily.asp"
+
+
+# ---------------------------------------------------------------------------
+# Вспомогательные функции
+# ---------------------------------------------------------------------------
+
+def _cache_file(for_date: date) -> Path:
+    """Возвращает путь к файлу кэша для указанной даты."""
+    base = Path(__file__).resolve().parents[1] / "data" / "cache"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{for_date.isoformat()}.json"
+
+
+def _fetch_cbr_rates(
+    for_date: date,
+    codes: Iterable[str] = SUPPORTED_CODES,
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> Dict[str, float]:
+    """Запрашивает курсы валют в ЦБ РФ.
+
+    :param for_date: дата, на которую требуется курс
+    :param codes: набор кодов ISO валют
+    :param retries: количество попыток при сетевых ошибках
+    :param timeout: таймаут запроса в секундах
+    :return: словарь ``{code: rate}``
+    :raises RuntimeError: при невозможности получить данные
+    """
+    params = {"date_req": for_date.strftime("%d/%m/%Y")}
+
+    for attempt in range(1, retries + 1):
+        try:
+            resp = requests.get(CBR_URL, params=params, timeout=timeout)
+            resp.raise_for_status()
+            resp.encoding = "windows-1251"
+            root = ET.fromstring(resp.text)
+        except (requests.RequestException, ET.ParseError) as exc:
+            if attempt == retries:
+                raise RuntimeError("Ошибка получения данных ЦБ РФ") from exc
+            time.sleep(attempt)
+            continue
+
+        rates: Dict[str, float] = {}
+        for valute in root.findall("Valute"):
+            char_code = valute.findtext("CharCode")
+            if char_code in codes:
+                nominal_text = valute.findtext("Nominal") or "1"
+                value_text = valute.findtext("Value") or "0"
+                try:
+                    nominal = int(nominal_text)
+                    value = float(value_text.replace(",", "."))
+                    rates[char_code] = value / nominal
+                except ValueError as exc:  # некорректные данные в XML
+                    raise RuntimeError("Ошибка разбора данных ЦБ РФ") from exc
+        missing = set(codes) - rates.keys()
+        if missing:
+            raise RuntimeError(
+                "Отсутствуют курсы валют: " + ", ".join(sorted(missing))
+            )
+        return rates
+    raise RuntimeError("Не удалось получить курсы валют ЦБ РФ")
+
+
+# ---------------------------------------------------------------------------
+# Публичное API
+# ---------------------------------------------------------------------------
+
+def get_cbr_rate(
+    for_date: date,
+    code: Literal["EUR", "USD", "JPY", "CNY"],
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> float:
+    """Возвращает курс указанной валюты по данным ЦБ РФ.
+
+    :param for_date: дата, на которую требуется курс
+    :param code: код ISO валюты
+    :param retries: количество попыток при сетевых ошибках
+    :param timeout: таймаут запроса в секундах
+    :return: курс в рублях за единицу валюты
+    """
+    return _fetch_cbr_rates(for_date, [code], retries=retries, timeout=timeout)[code]
+
+
+def get_cached_rates(
+    for_date: date,
+    codes: Iterable[str] = SUPPORTED_CODES,
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> Dict[str, float]:
+    """Возвращает курсы валют, используя файловый кэш.
+
+    Если данные на указанную дату отсутствуют, выполняется запрос к ЦБ РФ
+    с последующим сохранением в кэш.
+    """
+    cache = _cache_file(for_date)
+    if cache.exists():
+        try:
+            with cache.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            rates = data.get("rates", {})
+            if all(code in rates for code in codes):
+                return {code: rates[code] for code in codes}
+        except json.JSONDecodeError:
+            pass  # повреждённый кэш – перезапишем ниже
+
+    fresh = _fetch_cbr_rates(for_date, SUPPORTED_CODES, retries=retries, timeout=timeout)
+    payload = {
+        "date": for_date.isoformat(),
+        "provider": "CBR",
+        "base": "RUB",
+        "rates": fresh,
+    }
+    with cache.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False)
+    return {code: fresh[code] for code in codes}
+
+
+def get_cached_rate(
+    for_date: date,
+    code: Literal["EUR", "USD", "JPY", "CNY"],
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> float:
+    """Возвращает курс валюты из кэша или с запросом в ЦБ РФ."""
+    return get_cached_rates(for_date, [code], retries=retries, timeout=timeout)[code]
+
+
+def currency_to_rub(
+    amount: float,
+    code: Literal["EUR", "USD", "JPY", "CNY"],
+    for_date: date | None = None,
+) -> float:
+    """Конвертирует указанное количество валюты в рубли.
+
+    :param amount: сумма в иностранной валюте
+    :param code: код валюты
+    :param for_date: дата курса (по умолчанию сегодня)
+    :return: сумма в рублях
+    """
+    if for_date is None:
+        for_date = date.today()
+    rate = get_cached_rate(for_date, code)
+    return amount * rate
+
+
+def validate_or_prompt_rate(user_input: str) -> float:
+    """Проверяет корректность введённого курса валюты.
+
+    Допускается положительное число с не более чем четырьмя знаками после
+    десятичной точки. В качестве разделителя может быть использована запятая.
+
+    :param user_input: строка, введённая пользователем
+    :return: значение курса в виде float
+    :raises ValueError: при некорректном вводе
+    """
+    cleaned = user_input.strip().replace(",", ".")
+    try:
+        value = float(cleaned)
+    except ValueError as exc:
+        raise ValueError("Некорректное число") from exc
+    if value <= 0:
+        raise ValueError("Курс должен быть положительным")
+    parts = cleaned.split(".")
+    if len(parts) == 2 and len(parts[1]) > 4:
+        raise ValueError("Не более четырёх знаков после запятой")
+    return value
+
+
+if __name__ == "__main__":
+    today = date.today()
+    rates = get_cached_rates(today)
+    print(f"Курсы ЦБ РФ на {today}:")
+    for code, rate in rates.items():
+        print(f"  {code}: {rate:.4f} руб.")
+    amount = 100
+    rub = currency_to_rub(amount, "USD", today)
+    print(f"{amount} USD = {rub:.2f} RUB")


### PR DESCRIPTION
## Summary
- add service for fetching and caching CBR currency rates
- provide helpers to convert currencies and validate user input

## Testing
- `python -m py_compile bot_alista/services/rates.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c50003874832bb350705b2d76bcd2