### PR TITLE
Handle manual currency rates when CBR fetch fails

### DIFF
--- a/bot_alista/states.py
+++ b/bot_alista/states.py
@@ -13,3 +13,4 @@ class CalculationStates(StatesGroup):
     calc_power = State()
     calc_year = State()
     calc_weight = State()
+    manual_rate = State()


### PR DESCRIPTION
## Summary
- support manual entry of missing exchange rates via shared validator
- add FSM state and handlers to collect manual currency rates
- use provided rates during customs calculation

## Testing
- `python -m py_compile bot_alista/handlers/calculate.py bot_alista/states.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c58219ba0832bab47f18946750eec