### PR TITLE
Add personal tariff branch for individuals

### DIFF
--- a/bot_alista/constants.py
+++ b/bot_alista/constants.py
@@ -26,6 +26,10 @@ AGE_MAX = 30
 CURRENCY_CODES = ("EUR", "USD", "JPY", "CNY")
 
 # Prompts and error messages
+PROMPT_PERSON = "Выберите тип лица:"
+ERROR_PERSON = "Пожалуйста, выберите тип лица кнопкой."
+PROMPT_USAGE = "Выберите тип использования:"
+ERROR_USAGE = "Пожалуйста, выберите тип использования кнопкой."
 PROMPT_TYPE = "Выберите тип авто:"
 ERROR_TYPE = "Пожалуйста, выберите тип авто кнопкой."
 PROMPT_CURRENCY = "Выберите валюту стоимости:"

--- a/bot_alista/states.py
+++ b/bot_alista/states.py
@@ -6,6 +6,8 @@ from aiogram.fsm.state import State, StatesGroup
 class CalculationStates(StatesGroup):
     """Conversation steps for vehicle customs calculation."""
 
+    person_type = State()
+    usage_type = State()
     calc_type = State()
     currency_code = State()
     customs_value_amount = State()

--- a/bot_alista/tariff/personal_rates.py
+++ b/bot_alista/tariff/personal_rates.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class PersonalDutyRate:
+    """
+    Per-cc duty rate (EUR/cc) for individuals (personal use), bucketed by age × engine cc.
+    EDIT THESE VALUES to match your reference calculator exactly.
+    """
+    min_cc: int
+    max_cc: int
+    rate_eur_per_cc: float
+
+
+# Full per-cc table for individuals (personal use).
+# Keys are age buckets; values are ordered tuples of engine-cc intervals.
+# IMPORTANT: Tune these to match your reference (vl.broker).
+PERSONAL_RATES: Dict[str, Tuple[PersonalDutyRate, ...]] = {
+    # 1–3 years
+    "1_3y": (
+        PersonalDutyRate(0, 1000, 1.5),
+        PersonalDutyRate(1001, 1500, 1.7),
+        PersonalDutyRate(1501, 1800, 2.5),
+        PersonalDutyRate(1801, 2300, 2.7),
+        PersonalDutyRate(2301, 3000, 3.5),
+        PersonalDutyRate(3001, 10000, 5.5),
+    ),
+    # 3–5 years (your 2500 cc example lands here: 3.5 €/cc)
+    "3_5y": (
+        PersonalDutyRate(0, 1000, 1.5),
+        PersonalDutyRate(1001, 1500, 1.7),
+        PersonalDutyRate(1501, 1800, 2.5),
+        PersonalDutyRate(1801, 2300, 3.0),
+        PersonalDutyRate(2301, 3000, 3.5),   # ← key line for 2500 cc
+        PersonalDutyRate(3001, 10000, 5.5),
+    ),
+    # 5–7 years
+    "5_7y": (
+        PersonalDutyRate(0, 1000, 3.0),
+        PersonalDutyRate(1001, 1500, 3.2),
+        PersonalDutyRate(1501, 1800, 3.5),
+        PersonalDutyRate(1801, 2300, 4.8),
+        PersonalDutyRate(2301, 3000, 5.7),
+        PersonalDutyRate(3001, 10000, 7.5),
+    ),
+    # > 7 years
+    "7p_y": (
+        PersonalDutyRate(0, 1000, 3.0),
+        PersonalDutyRate(1001, 1500, 3.2),
+        PersonalDutyRate(1501, 1800, 3.5),
+        PersonalDutyRate(1801, 2300, 5.0),
+        PersonalDutyRate(2301, 3000, 5.7),
+        PersonalDutyRate(3001, 10000, 7.5),
+    ),
+}
+
+# Customs clearance fee (RUB) to display and add for individuals.
+# Adjust if your reference differs.
+CUSTOMS_CLEARANCE_FEE_RUB: float = 4269.0
+
+
+def _age_bucket(age_years: float) -> str:
+    """
+    Returns one of: '1_3y', '3_5y', '5_7y', '7p_y'.
+    0–1y falls into the nearest bucket '1_3y'.
+    """
+    if age_years < 1:
+        return "1_3y"
+    if 1 <= age_years < 3:
+        return "1_3y"
+    if 3 <= age_years < 5:
+        return "3_5y"
+    if 5 <= age_years < 7:
+        return "5_7y"
+    return "7p_y"
+
+
+def _find_rate_eur_per_cc(engine_cc: int, age_years: float) -> float:
+    if engine_cc <= 0:
+        raise ValueError("Engine displacement must be > 0 cc.")
+    bucket = _age_bucket(age_years)
+    for row in PERSONAL_RATES[bucket]:
+        if row.min_cc <= engine_cc <= row.max_cc:
+            return row.rate_eur_per_cc
+    # Fallback to top range if nothing matched
+    return PERSONAL_RATES[bucket][-1].rate_eur_per_cc
+
+
+def calc_individual_personal_duty_eur(engine_cc: int, age_years: float) -> float:
+    """
+    Duty in EUR for individuals (personal use) = engine_cc × per-cc rate (EUR/cc).
+    """
+    rate = _find_rate_eur_per_cc(engine_cc, age_years)
+    return round(engine_cc * rate, 2)


### PR DESCRIPTION
## Summary
- add EUR/cc rate table and customs clearance fee for individuals
- route calculations through unified `calc_breakdown_with_mode`
- extend FSM to capture person and usage type with navigation

## Testing
- `python -m py_compile tariff_engine.py bot_alista/tariff/personal_rates.py bot_alista/constants.py bot_alista/states.py bot_alista/handlers/calculate.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5f3cc1a0832ba0f1ce0c2cbb447b