### PR TITLE
Add tiered clearance fee and pretty formatter

### DIFF
--- a/bot_alista/formatting.py
+++ b/bot_alista/formatting.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def _fmt_money_rub(v: float) -> str:
+    """
+    Format RUB with thin spaces and 2 decimals.
+    """
+    s = f"{v:,.2f}"
+    return s.replace(",", " ").replace(".00", "") + " ₽"
+
+
+def _fmt_money_generic(v: float, suffix: str) -> str:
+    s = f"{v:,.2f}"
+    s = s.replace(",", " ")
+    if suffix:
+        return f"{s} {suffix}"
+    return s
+
+
+def format_result_message(
+    *,
+    currency_code: str,
+    price_amount: float,
+    rates: Dict[str, float],
+    meta: Dict[str, Any],
+    core: Dict[str, Any],
+    util_fee_rub: float,
+) -> str:
+    """
+    Build a user-friendly Telegram message with emojis and clear sections.
+
+    Args:
+        currency_code: "EUR"|"USD"|"JPY"|"CNY"
+        price_amount: original price amount in the selected currency
+        rates: mapping like {"EUR": 92.86, "USD": 79.87, ...} (RUB per 1 unit)
+        meta: extra info (e.g., person/usage, engine, age bucket info, notes)
+        core: result from calc_breakdown_with_mode(...)
+        util_fee_rub: utilization fee in RUB
+
+    Returns:
+        A formatted Telegram message string.
+    """
+    br = core["breakdown"]
+    total_no_util = br["total_rub"]
+    total_with_util = round(total_no_util + util_fee_rub, 2)
+
+    usd_rate = rates.get("USD")
+    eur_rate = rates.get("EUR")
+
+    duty_rate_info = meta.get("duty_rate_info", "")
+    age_info = meta.get("age_info", "")
+    person_usage = meta.get("person_usage", "")
+    extra_notes = meta.get("extra_notes", [])
+
+    lines: list[str] = []
+    lines.append("📦 Расчёт таможенных платежей:\n")
+
+    lines.append(f"💵 Стоимость авто: {_fmt_money_generic(price_amount, currency_code)}")
+    if usd_rate is not None:
+        lines.append(f"💱 Курс USD: {_fmt_money_generic(usd_rate, '₽')}")
+    if eur_rate is not None:
+        lines.append(f"💱 Курс EUR: {_fmt_money_generic(eur_rate, '₽')}")
+    lines.append(f"💰 Таможенная стоимость: {_fmt_money_rub(br['customs_value_rub'])}\n")
+
+    lines.append(f"🛃 Пошлина: {_fmt_money_rub(br['duty_rub'])}")
+    if "clearance_fee_rub" in br:
+        lines.append(
+            f"📄 Сбор за таможенное оформление: {_fmt_money_rub(br['clearance_fee_rub'])}"
+        )
+    lines.append(f"🚫 НДС: {_fmt_money_rub(br.get('vat_rub', 0.0))}")
+    lines.append(f"🚫 Акциз: {_fmt_money_rub(br.get('excise_rub', 0.0))}\n")
+
+    lines.append(f"📌 ИТОГ без утильсбора: {_fmt_money_rub(total_no_util)}\n")
+    lines.append(f"♻️ Утилизационный сбор: {_fmt_money_rub(util_fee_rub)}")
+    lines.append(f"✅ ИТОГ с утильсбором: **{_fmt_money_rub(total_with_util)}**\n")
+
+    lines.append("──────────────")
+    lines.append("ℹ️ Примечания:")
+    if person_usage:
+        lines.append(f"• {person_usage}")
+    if age_info:
+        lines.append(f"• {age_info}")
+    if duty_rate_info:
+        lines.append(f"• Ставка пошлины: {duty_rate_info}")
+    for n in extra_notes:
+        lines.append(f"• {n}")
+
+    return "\n".join(lines)

--- a/bot_alista/tariff/personal_rates.py
+++ b/bot_alista/tariff/personal_rates.py
@@ -21,12 +21,12 @@ class PersonalDutyRate:
 PERSONAL_RATES: Dict[str, Tuple[PersonalDutyRate, ...]] = {
     # 1–3 years
     "1_3y": (
-        PersonalDutyRate(0, 1000, 1.5),
-        PersonalDutyRate(1001, 1500, 1.7),
-        PersonalDutyRate(1501, 1800, 2.5),
-        PersonalDutyRate(1801, 2300, 2.7),
-        PersonalDutyRate(2301, 3000, 3.5),
-        PersonalDutyRate(3001, 10000, 5.5),
+        PersonalDutyRate(0, 1000, 3.5),
+        PersonalDutyRate(1001, 1500, 5.5),   # matches vl.broker for 1500 cc
+        PersonalDutyRate(1501, 1800, 5.5),
+        PersonalDutyRate(1801, 2300, 6.2),   # matches vl.broker for 2000 cc
+        PersonalDutyRate(2301, 3000, 7.5),
+        PersonalDutyRate(3001, 10000, 7.5),
     ),
     # 3–5 years (your 2500 cc example lands here: 3.5 €/cc)
     "3_5y": (
@@ -53,7 +53,7 @@ PERSONAL_RATES: Dict[str, Tuple[PersonalDutyRate, ...]] = {
         PersonalDutyRate(1501, 1800, 3.5),
         PersonalDutyRate(1801, 2300, 5.0),
         PersonalDutyRate(2301, 3000, 5.7),
-        PersonalDutyRate(3001, 10000, 7.5),
+        PersonalDutyRate(3001, 10000, 5.7),  # was 7.5; must be 5.7
     ),
 }
 


### PR DESCRIPTION
## Summary
- adjust personal duty table so small and large engines match vl.broker examples
- introduce tiered customs-clearance fee and apply it for individual personal imports
- add reusable emoji-based result formatter and use it in Telegram handler

## Testing
- `python -m py_compile bot_alista/tariff/personal_rates.py tariff_engine.py bot_alista/formatting.py bot_alista/handlers/calculate.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6663aa68832ba77df0782ac422f9