### PR TITLE
Update personal duty rates and expose applied rate

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -400,8 +400,11 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         duty_eur = core["breakdown"].get("duty_eur")
         rate_line = ""
         if duty_eur and engine_cc:
-            rate_eur_per_cc = round(float(duty_eur) / float(engine_cc), 2)
-            rate_line = f"{rate_eur_per_cc} €/см³ × {engine_cc} см³"
+            try:
+                rate_eur_per_cc = round(float(duty_eur) / float(engine_cc), 2)
+                rate_line = f"{rate_eur_per_cc} €/cc × {engine_cc} cc"
+            except Exception:
+                rate_line = ""
 
         meta = {
             "person_usage": (

--- a/bot_alista/tariff/personal_rates.py
+++ b/bot_alista/tariff/personal_rates.py
@@ -22,19 +22,19 @@ PERSONAL_RATES: Dict[str, Tuple[PersonalDutyRate, ...]] = {
     # 1–3 years
     "1_3y": (
         PersonalDutyRate(0, 1000, 3.5),
-        PersonalDutyRate(1001, 1500, 5.5),   # matches vl.broker for 1500 cc
+        PersonalDutyRate(1001, 1500, 5.5),
         PersonalDutyRate(1501, 1800, 5.5),
-        PersonalDutyRate(1801, 2300, 6.2),   # matches vl.broker for 2000 cc
-        PersonalDutyRate(2301, 3000, 8.4),   # updated per-cc rate for 2301–3000 cc
-        PersonalDutyRate(3001, 10000, 8.4),
+        PersonalDutyRate(1801, 2300, 6.2),
+        PersonalDutyRate(2301, 3000, 5.5),   # was 8.4 → must be 5.5 €/cc
+        PersonalDutyRate(3001, 10000, 7.5),
     ),
-    # --- PATCH: 3–5 years bucket so 2301–3000 cc = 3.0 €/cc ---
+    # 3–5 years
     "3_5y": (
         PersonalDutyRate(0, 1000, 1.5),
         PersonalDutyRate(1001, 1500, 1.7),
         PersonalDutyRate(1501, 1800, 2.5),
         PersonalDutyRate(1801, 2300, 3.0),
-        PersonalDutyRate(2301, 3000, 3.0),  # was 3.5 -> must be 3.0 €/cc
+        PersonalDutyRate(2301, 3000, 3.0),   # was 3.5 → must be 3.0 €/cc
         PersonalDutyRate(3001, 10000, 5.5),
     ),
     # 5–7 years


### PR DESCRIPTION
## Summary
- Adjust individual per-cc duty tables for ≤ 3 years and 3–5 years engine brackets
- Display applied duty rate per cc in calculation notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c73298f74832b896c36491b4b47fa