### PR TITLE
Add robust age bucket resolver

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -346,7 +346,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         person_type = "individual" if person_ru == "Физическое лицо" else "company"
         usage_type = "personal" if usage_ru == "Личное" else "commercial"
 
-        decl_date = date.today()
+        decl_date = data.get("decl_date") or date.today()
         manual_rates = data.get("manual_rates", {})
         needed = {currency_code, "EUR"}
         try:
@@ -381,7 +381,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         customs_value_eur = round(customs_value_rub / eur_rate, 2)
 
         fuel_type = car_type
-        age_over_3 = data.get("age_over_3", False)
+        age_over_3 = bool(data.get("age_over_3", False))
 
         core = calc_breakdown_rules(
             person_type=person_type,

--- a/bot_alista/rules/age.py
+++ b/bot_alista/rules/age.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Set
+
+@dataclass(frozen=True)
+class AgeBuckets:
+    has_le3: bool
+    has_3_5: bool
+    has_5_7: bool
+    has_gt7: bool
+    has_gt5: bool
+
+def _labels_set(labels: Iterable[str]) -> Set[str]:
+    return { (s or "").strip() for s in labels if (s or "").strip() }
+
+def detect_buckets(available_labels: Iterable[str]) -> AgeBuckets:
+    L = _labels_set(available_labels)
+    return AgeBuckets(
+        has_le3=("≤3" in L or "<=3" in L or "1–3" in L or "1-3" in L or "до 3" in L),
+        has_3_5=("3–5" in L or "3-5" in L),
+        has_5_7=("5–7" in L or "5-7" in L),
+        has_gt7=(">7" in L or "7+" in L or "старше 7" in L or "более 7" in L),
+        has_gt5=(">5" in L or "5+" in L or "старше 5" in L or "более 5" in L),
+    )
+
+def compute_actual_age_years(production_year: int, decl_date: date) -> float:
+    # conservative: assume Dec 31st if month/day unknown
+    prod = date(production_year, 12, 31)
+    delta = decl_date - prod
+    return max(0.0, delta.days / 365.2425)
+
+def pick_ul_age_label(actual_age: float, buckets: AgeBuckets) -> str:
+    """
+    For UL we always use factual age.
+    Priority: ≤3 → 3–5 → 5–7 → >7 (or >5).
+    """
+    if actual_age <= 3.0 and buckets.has_le3:
+        return "≤3"
+    if actual_age <= 5.0 and buckets.has_3_5:
+        return "3–5"
+    if actual_age <= 7.0 and buckets.has_5_7:
+        return "5–7"
+    if buckets.has_gt7:
+        return ">7"
+    if buckets.has_gt5:
+        return ">5"
+    # last resort: choose the youngest available in order
+    if buckets.has_3_5: return "3–5"
+    if buckets.has_5_7: return "5–7"
+    if buckets.has_le3: return "≤3"
+    return ">7"
+
+def pick_fl_age_label(user_over3: bool, actual_age: float, buckets: AgeBuckets) -> str:
+    """
+    For FL:
+      - If user chose "not older than 3": force ≤3 (or nearest younger).
+      - If user chose "older than 3": choose among 3–5 / 5–7 / >7 (or >5) by actual age.
+    """
+    if not user_over3:
+        # Prefer ≤3; if absent, pick the youngest available
+        if buckets.has_le3: return "≤3"
+        if buckets.has_3_5: return "3–5"
+        if buckets.has_5_7: return "5–7"
+        if buckets.has_gt7: return ">7"
+        if buckets.has_gt5: return ">5"
+        return "≤3"
+
+    # user_over3 = True
+    if actual_age <= 5.0 and buckets.has_3_5:
+        return "3–5"
+    if actual_age <= 7.0 and buckets.has_5_7:
+        return "5–7"
+    if buckets.has_gt7:
+        return ">7"
+    if buckets.has_gt5:
+        return ">5"
+    # fallback if 3–5/5–7 missing:
+    if buckets.has_3_5: return "3–5"
+    if buckets.has_5_7: return "5–7"
+    # worst-case: can't distinguish; push to >7 or ≤3 if only that exists
+    if buckets.has_le3: return "≤3"
+    return ">7"

--- a/bot_alista/rules/loader.py
+++ b/bot_alista/rules/loader.py
@@ -137,3 +137,18 @@ def pick_rule(rows: List[RuleRow], *, segment: str, category: str, fuel: str,
             if r.segment == segment and r.category == category and r.fuel == fuel and r.age_bucket == age_bucket
             and _match(engine_cc, r.cc_from, r.cc_to)]
     return cand[0] if cand else None
+
+def get_available_age_labels() -> set[str]:
+    rows = load_rules()
+    return { r.age_bucket for r in rows if r.age_bucket }
+
+def normalize_fuel_label(user_fuel: str) -> str:
+    s = (user_fuel or "").strip().lower()
+    if any(x in s for x in ("элект", "bev", "electric")):
+        return "Электро"
+    if any(x in s for x in ("гибрид", "hev", "phev", "hybrid")):
+        return "Гибрид"
+    if "диз" in s or "diesel" in s:
+        return "Дизель"
+    # default
+    return "Бензин"


### PR DESCRIPTION
## Summary
- add CSV-backed age bucket resolver with fallbacks
- expose available age labels and normalize fuel strings
- unify tariff calculation to use factual age and resolver for FL/UL
- ensure handlers pass declaration date and age choice

## Testing
- `python -m py_compile bot_alista/rules/age.py bot_alista/rules/loader.py bot_alista/handlers/calculate.py tariff_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed1a9f2f0832ba5e60b529cdf37e9