### PR TITLE
Cache rules once and reuse in tariff calculations

### DIFF
--- a/bot_alista/rules/engine.py
+++ b/bot_alista/rules/engine.py
@@ -1,13 +1,13 @@
 # bot_alista/rules/engine.py
 from __future__ import annotations
-from typing import Literal, Dict, Any
-from .loader import load_rules, pick_rule
+from typing import Literal, Dict, Any, List
+from .loader import pick_rule, RuleRow
 
 PersonType = Literal["individual", "company"]
 UsageType = Literal["personal", "commercial"]
 
 def calc_fl_stp(
-    *, customs_value_eur: float, eur_rub_rate: float, engine_cc: int,
+    *, rules: List[RuleRow], customs_value_eur: float, eur_rub_rate: float, engine_cc: int,
     segment: str, category: str, fuel: str, age_bucket: str
 ) -> Dict[str, Any]:
     """
@@ -17,7 +17,6 @@ def calc_fl_stp(
       - Some datasets contain both (use max(ad valorem, min €/cc)).
     Returns duty_eur and duty_rub as the 'STP' (no separate VAT/excise).
     """
-    rules = load_rules()
     rule = pick_rule(rules, segment=segment, category=category, fuel=fuel,
                      age_bucket=age_bucket, engine_cc=engine_cc, engine_hp=None)
     if not rule:
@@ -46,13 +45,13 @@ def calc_fl_stp(
     }
 
 def calc_ul(
-    *, customs_value_eur: float, eur_rub_rate: float, engine_cc: int, engine_hp: int,
-    segment: str, category: str, fuel: str, age_bucket: str, vat_override_pct: float | None = None
+    *, rules: List[RuleRow], customs_value_eur: float, eur_rub_rate: float,
+    engine_cc: int, engine_hp: int, segment: str, category: str,
+    fuel: str, age_bucket: str, vat_override_pct: float | None = None
 ) -> Dict[str, Any]:
     """
     Companies/commercial — ad valorem vs min €/cc vs specific €/cc + excise + VAT.
     """
-    rules = load_rules()
     rule = pick_rule(rules, segment=segment, category=category, fuel=fuel,
                      age_bucket=age_bucket, engine_cc=engine_cc, engine_hp=engine_hp)
     if not rule:

--- a/bot_alista/rules/loader.py
+++ b/bot_alista/rules/loader.py
@@ -138,8 +138,8 @@ def pick_rule(rows: List[RuleRow], *, segment: str, category: str, fuel: str,
             and _match(engine_cc, r.cc_from, r.cc_to)]
     return cand[0] if cand else None
 
-def get_available_age_labels() -> set[str]:
-    rows = load_rules()
+def get_available_age_labels(rows: List[RuleRow]) -> set[str]:
+    """Return a set of age bucket labels available in provided rules."""
     return { r.age_bucket for r in rows if r.age_bucket }
 
 def normalize_fuel_label(user_fuel: str) -> str:

--- a/tariff_engine.py
+++ b/tariff_engine.py
@@ -380,7 +380,7 @@ def calc_breakdown_rules(
     decl_date = decl_date or date.today()
     fuel_norm = normalize_fuel_label(fuel_type)
     rules = load_rules()
-    labels = get_available_age_labels()
+    labels = get_available_age_labels(rules)
     buckets = detect_buckets(labels)
 
     customs_value_rub = round(customs_value_eur * eur_rub_rate, 2)
@@ -391,12 +391,12 @@ def calc_breakdown_rules(
         fl_age_label = pick_fl_age_label(age_choice_over3, actual_age, buckets)
 
         core = calc_fl_stp(
+            rules=rules,
             customs_value_eur=customs_value_eur,
             eur_rub_rate=eur_rub_rate,
             engine_cc=int(engine_cc or 0),
             segment=segment, category=category,
             fuel=fuel_norm, age_bucket=fl_age_label,
-            factual_age_years=actual_age,
         )
         fee_rub = calc_clearance_fee_rub(customs_value_rub)
         total_no_util = round(core["duty_rub"] + fee_rub, 2)
@@ -450,13 +450,13 @@ def calc_breakdown_rules(
     ul_age_label = pick_ul_age_label(actual_age, buckets)
 
     core = calc_ul(
+        rules=rules,
         customs_value_eur=customs_value_eur,
         eur_rub_rate=eur_rub_rate,
         engine_cc=int(engine_cc or 0),
         engine_hp=int(engine_hp or 0),
         segment=segment, category=category,
         fuel=fuel_norm, age_bucket=ul_age_label,
-        factual_age_years=actual_age,
     )
 
     fee_rub = calc_clearance_fee_rub(customs_value_rub)


### PR DESCRIPTION
## Summary
- Cache rule rows in `calc_breakdown_rules` and reuse across age label detection and duty calculations.
- Updated `get_available_age_labels`, `calc_fl_stp`, and `calc_ul` to accept preloaded rules instead of loading internally.

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689edb535494832b920d58b8e9470a17