### PR TITLE
Cache rule loading and reuse cached metadata

### DIFF
--- a/bot_alista/rules/engine.py
+++ b/bot_alista/rules/engine.py
@@ -1,6 +1,10 @@
 # bot_alista/rules/engine.py
 from __future__ import annotations
+
 from typing import Literal, Dict, Any, List
+
+# Caller should provide a preloaded (and ideally cached) list of RuleRow
+# entries to avoid repeated CSV parsing in performance-sensitive paths.
 from .loader import pick_rule, RuleRow
 
 PersonType = Literal["individual", "company"]


### PR DESCRIPTION
## Summary
- cache CSV rule loading with `lru_cache`
- centralize rule/age-label/bucket computation in tariff engine and reuse via cached helper
- clarify that rule-based calculations expect preloaded (cached) rule sets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee8da973c832ba42aa2987725926a