### PR TITLE
Fix customs calculations and add tests

### DIFF
--- a/tests/test_calc_min.py
+++ b/tests/test_calc_min.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from calculator import calculate_individual, calculate_company
+
+
+@pytest.fixture(autouse=True)
+def mock_rates(monkeypatch):
+    rates = {"USD": 79.87, "EUR": 92.86, "RUB": 1.0}
+
+    def fake_get_rate(code):
+        return rates[code]
+
+    monkeypatch.setattr("calculator._get_rate", fake_get_rate)
+
+
+def test_fl_under3_by_value():
+    res = calculate_individual(customs_value=20000, currency="USD", engine_cc=2500,
+                               production_year=2022, fuel="Бензин")
+    assert res["duty_rub"] > 600_000
+    assert "clearance_fee_rub" in res
+
+
+def test_fl_over3_specific():
+    res = calculate_individual(customs_value=15000, currency="USD", engine_cc=3000,
+                               production_year=2015, fuel="Бензин")
+    assert res["duty_rub"] > 1_200_000
+
+
+def test_ul_under3_15pct():
+    res = calculate_company(customs_value=30000, currency="USD", engine_cc=2000,
+                            production_year=2024, fuel="Бензин", hp=150)
+    assert res["duty_rub"] > 300_000


### PR DESCRIPTION
## Summary
- align individual calculations with EUR-based customs value grid, STP for EVs, and include clearance fee
- apply 15% ad valorem for young company imports and enforce strict CBR rates
- add regression tests for individual and company scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0069c010832bab99b490f5ece511