### PR TITLE
Use cached currency rates to avoid network errors

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 import math
 
-from bot_alista.services.rates import get_cbr_rate
+from bot_alista.services.rates import get_cached_rate
 
 # ---------------------------------------------------------------------------
 # Вспомогательные структуры и таблицы тарифов
@@ -114,11 +114,12 @@ def _format_money(value: float) -> str:
 
 def _get_rate(code: Currency) -> float:
     """Получить курс валюты к рублю на сегодня."""
-    if code == "RUB":
+    if code.upper() == "RUB":
         return 1.0
     today = date.today()
     try:
-        return get_cbr_rate(today, code)
+        # Используем файловый кэш, чтобы расчёт работал без сети
+        return get_cached_rate(today, code.upper())
     except Exception:
         # Не искажаем расчёт фиктивными курсами
         raise RuntimeError("Курс ЦБ недоступен — попробуйте позже")

--- a/tests/test_rate_cache.py
+++ b/tests/test_rate_cache.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from calculator import calculate_individual
+
+
+def test_uses_cached_rate_when_network_fails(monkeypatch):
+    called = []
+
+    def fake_cached_rate(for_date, code, retries=3, timeout=5.0):
+        called.append(code)
+        rates = {"USD": 80.0, "EUR": 90.0}
+        return rates[code]
+
+    def fail_network(*args, **kwargs):
+        raise AssertionError("network should not be called")
+
+    # Patch both the calculator's alias and the service function for safety
+    monkeypatch.setattr("calculator.get_cached_rate", fake_cached_rate)
+    monkeypatch.setattr("bot_alista.services.rates.get_cached_rate", fake_cached_rate)
+    monkeypatch.setattr("bot_alista.services.rates._fetch_cbr_rates", fail_network)
+
+    res = calculate_individual(
+        customs_value=100,
+        currency="USD",
+        engine_cc=1000,
+        production_year=2022,
+        fuel="Бензин",
+    )
+
+    assert called == ["USD", "EUR"]
+    assert res["currency_rate"] == 80.0
+    assert res["eur_rate"] == 90.0


### PR DESCRIPTION
## Summary
- Load currency rates from the local cache so calculations work offline
- Add test covering fallback to cached rates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f08c41440832b8fe350f89f8bdc9d