### PR TITLE
Implement user request flow

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 from aiogram import Bot, Dispatcher
 from config import TOKEN
-from handlers import menu, calculate, navigation
+from handlers import menu, calculate, navigation, request
 
 
 async def main():
@@ -11,6 +11,7 @@ async def main():
     dp.include_router(menu.router)
     dp.include_router(calculate.router)
     dp.include_router(navigation.router)
+    dp.include_router(request.router)
 
     await dp.start_polling(bot)
 

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -1,0 +1,43 @@
+"""Handlers for processing contact requests from the main menu."""
+
+from aiogram import Router, types, F
+from aiogram.fsm.context import FSMContext
+
+from states import RequestStates
+from keyboards.navigation import back_menu
+from utils.reset import reset_to_menu
+from services.email import send_email
+from config import EMAIL_TO
+
+router = Router()
+
+@router.message(F.text == "📝 Оставить заявку")
+async def start_request(message: types.Message, state: FSMContext) -> None:
+    """Initiate the request conversation by asking for contact details."""
+    await state.set_state(RequestStates.contact)
+    await message.answer(
+        "Пожалуйста, отправьте ваш номер телефона или контактную информацию.",
+        reply_markup=back_menu(),
+    )
+
+
+@router.message(RequestStates.contact)
+async def handle_contact(message: types.Message, state: FSMContext) -> None:
+    """Receive contact info, send it via email and return to main menu."""
+    if message.text in {"🏠 Главное меню", "⬅ Назад"}:
+        await reset_to_menu(message, state)
+        return
+
+    contact = message.text.strip()
+    body = (
+        f"Заявка от {message.from_user.full_name} (@{message.from_user.username}):\n"
+        f"{contact}"
+    )
+    success = send_email(EMAIL_TO, "Новая заявка", body)
+
+    if success:
+        await message.answer("✅ Спасибо! Мы свяжемся с вами в ближайшее время.")
+    else:
+        await message.answer("❌ Не удалось отправить заявку. Попробуйте позже.")
+
+    await reset_to_menu(message, state)

--- a/bot_alista/states.py
+++ b/bot_alista/states.py
@@ -16,3 +16,9 @@ class CalculationStates(StatesGroup):
     calc_year = State()
     age_over_3 = State()
     manual_rate = State()
+
+
+class RequestStates(StatesGroup):
+    """Conversation steps for submitting a contact request."""
+
+    contact = State()


### PR DESCRIPTION
## Summary
- add RequestStates and request handler to collect contact info
- send request data via email and return users to main menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0be85620832ba6377f3ef8546aa1