### PR TITLE
Update 2025 util-fee coefficients and add regression tests

### DIFF
--- a/bot_alista/tariff/util_fee.py
+++ b/bot_alista/tariff/util_fee.py
@@ -266,8 +266,8 @@ UTIL_CONFIG: Dict = {
             "cc<=1000": 0.17,
             "cc1000_2000": 0.17,
             "cc2000_3000": 0.17,
-            "cc3000_3500": 107.67,
-            "cc>3500": 137.11,
+            "cc3000_3500": 0.17,
+            "cc>3500": 0.17,
         },
         ">3y": {
             "ev": 0.26,
@@ -275,11 +275,11 @@ UTIL_CONFIG: Dict = {
             "cc<=1000": 0.26,
             "cc1000_2000": 0.26,
             "cc2000_3000": 0.26,
-            "cc3000_3500": 164.84,
-            "cc>3500": 180.24,
+            "cc3000_3500": 0.26,
+            "cc>3500": 0.26,
         },
     },
-    "coefficients_commercial": {"ev_or_hybrid": 33.37, "default": 10.0},
+    "coefficients_commercial": {"ev_or_hybrid": 33.37, "default": 22.25},
     "date_rules": {
         "2025-05-01": {
             "formula": "ed_plus_half_diff",

--- a/calculator.py
+++ b/calculator.py
@@ -70,10 +70,11 @@ UTIL_COEFF_FL = {
 
 UTIL_BASE_UL = 20_000  # базовая ставка для юр. лиц с 01.05.2025
 UTIL_COEFF_UL = {
-    "under_3": 0.2,
-    "3_5": 0.34,
-    "5_7": 0.43,
-    "over_7": 0.62,
+    "under_3": 33.37,
+    "3_5": 22.25,
+    "5_7": 15.75,
+    "7_10": 10.96,
+    "over_10": 6.73,
 }
 
 CLEARANCE_FEE_TABLE = [
@@ -134,10 +135,12 @@ def _age_category(year: int, person_type: str) -> str:
         return "3_5"
     if person_type == "fl":
         return "over_5"
-    # для юр. лиц различаем 5–7 и старше 7
+    # для юр. лиц: детализированные возрастные категории
     if 5 < age <= 7:
         return "5_7"
-    return "over_7"
+    if 7 < age <= 10:
+        return "7_10"
+    return "over_10"
 
 
 def _pick_rate(table, engine_cc: int):
@@ -268,7 +271,7 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
     vat_rub = (value_rub + duty_rub + excise_rub) * 0.20
 
     # Утильсбор
-    util_coeff = UTIL_COEFF_UL[age_cat if age_cat in UTIL_COEFF_UL else "over_7"]
+    util_coeff = UTIL_COEFF_UL.get(age_cat, UTIL_COEFF_UL["over_10"])
     util_rub = UTIL_BASE_UL * util_coeff
 
     # Сбор за оформление

--- a/tests/test_util_fee.py
+++ b/tests/test_util_fee.py
@@ -1,0 +1,39 @@
+from datetime import date
+from copy import deepcopy
+
+from bot_alista.tariff.util_fee import calc_util_rub, UTIL_CONFIG
+
+
+def test_util_fee_individual_personal():
+    config = deepcopy(UTIL_CONFIG)
+    fee = calc_util_rub(
+        person_type="individual",
+        usage="personal",
+        engine_cc=1800,
+        fuel="ice",
+        vehicle_kind="passenger",
+        age_years=2.0,
+        date_decl=date(2025, 6, 1),
+        avg_vehicle_cost_rub=None,
+        actual_costs_rub=None,
+        config=config,
+    )
+    assert fee == 3400.0
+
+
+def test_util_fee_company_commercial():
+    config = deepcopy(UTIL_CONFIG)
+    fee = calc_util_rub(
+        person_type="company",
+        usage="commercial",
+        engine_cc=2000,
+        fuel="ice",
+        vehicle_kind="passenger",
+        age_years=1.0,
+        date_decl=date(2025, 6, 1),
+        avg_vehicle_cost_rub=None,
+        actual_costs_rub=None,
+        config=config,
+    )
+    assert fee == 445000.0
+


### PR DESCRIPTION
## Summary
- update legal-entity utilization-fee coefficients and extend age brackets
- align tariff config with 2025 schedule for personal and commercial usage
- add regression tests for individual and corporate util-fee calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0e6f7d70832bba338d5cd239287b