### PR TITLE
validate negative value in under-3 rule lookup

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -134,8 +134,26 @@ FL_STP_UNDER3_BY_VALUE_EUR = [
     (math.inf,{"pct": 0.48, "min": 20.0}),
 ]
 
-
 def pick_fl_under3_rule_by_value_eur(value_eur: float) -> dict:
+    """Return duty rule for a vehicle under three years old by customs value.
+
+    Parameters
+    ----------
+    value_eur : float
+        Customs value of the vehicle in euros.
+
+    Returns
+    -------
+    dict
+        Rule containing percentage (``pct``) and minimum euro-per-cc value.
+
+    Raises
+    ------
+    ValueError
+        If ``value_eur`` is negative.
+    """
+    if value_eur < 0:
+        raise ValueError("value_eur must be non-negative")
     for lim, rule in FL_STP_UNDER3_BY_VALUE_EUR:
         if value_eur <= lim:
             return rule

--- a/tests/test_calc_min.py
+++ b/tests/test_calc_min.py
@@ -5,7 +5,11 @@ import math
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from calculator import calculate_individual, calculate_company
+from calculator import (
+    calculate_individual,
+    calculate_company,
+    pick_fl_under3_rule_by_value_eur,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -55,3 +59,8 @@ def test_ul_5_7_diesel_brackets():
     eur_rate = 92.86
     assert math.isclose(res_small["duty_rub"], 1200 * 3.2 * eur_rate, rel_tol=1e-6)
     assert math.isclose(res_large["duty_rub"], 2600 * 5.0 * eur_rate, rel_tol=1e-6)
+
+
+def test_pick_fl_under3_rule_negative():
+    with pytest.raises(ValueError):
+        pick_fl_under3_rule_by_value_eur(-100)


### PR DESCRIPTION
## Summary
- document customs value rule selector and guard against negative input
- test negative value for under-3 rule lookup

## Testing
- `pytest -q` *(fails: tests/test_tariff_rules.py::test_clearance_fee_brackets)*
- `pytest tests/test_calc_min.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2dcbc3514832b8beb9ba59d3cd316