### PR TITLE
Validate currency codes

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -152,12 +152,17 @@ def _format_money(value: float) -> str:
 
 def _get_rate(code: Currency) -> float:
     """Получить курс валюты к рублю на сегодня."""
-    if code.upper() == "RUB":
+    code = code.upper()
+    if code not in SUPPORTED_CURRENCIES:
+        raise ValueError(
+            f"Unsupported currency: {code}. Supported: {', '.join(SUPPORTED_CURRENCIES)}"
+        )
+    if code == "RUB":
         return 1.0
     today = date.today()
     try:
         # Используем файловый кэш, чтобы расчёт работал без сети
-        return get_cached_rate(today, code.upper())
+        return get_cached_rate(today, code)
     except Exception:
         # Не искажаем расчёт фиктивными курсами
         raise RuntimeError("Курс ЦБ недоступен — попробуйте позже")

--- a/tests/test_supported_currencies.py
+++ b/tests/test_supported_currencies.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import calculator
+
+
+@pytest.mark.parametrize("code", calculator.SUPPORTED_CURRENCIES)
+def test_get_rate_supported_currencies(monkeypatch, code):
+    called = []
+
+    def fake_cached_rate(for_date, c, retries=3, timeout=5.0):
+        called.append(c)
+        return 42.0
+
+    monkeypatch.setattr("calculator.get_cached_rate", fake_cached_rate)
+    rate = calculator._get_rate(code)
+    if code == "RUB":
+        assert rate == 1.0
+        assert called == []
+    else:
+        assert rate == 42.0
+        assert called == [code]
+
+
+def test_get_rate_unsupported_currency(monkeypatch):
+    def fake_cached_rate(*args, **kwargs):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr("calculator.get_cached_rate", fake_cached_rate)
+    with pytest.raises(ValueError):
+        calculator._get_rate("GBP")


### PR DESCRIPTION
## Summary
- validate currency codes in `_get_rate` against supported list
- add tests for supported and unsupported currency handling

## Testing
- `pytest` *(fails: tests/test_tariff_rules.py::test_clearance_fee_brackets...)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dcbcd90c832bb53d3966045e0150