### PR TITLE
Correct electric vehicle duty calculation to use EUR value

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -293,8 +293,8 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
 
     # Пошлина
     if fuel.lower() == "электро":
-        duty_eur = customs_value * 0.15
-        trace.append("Электро: 15% адвалор")
+        duty_eur = value_eur * 0.15
+        trace.append(f"Электро: 15% от {value_eur:.2f} EUR")
     else:
         if age_cat == "under_3":
             # ЮЛ ≤3 лет: 15% адвалор (если CSV не даёт иное для конкретного кода)


### PR DESCRIPTION
## Summary
- Fix company duty calculation for electric vehicles to apply 15% to the EUR value
- Trace now reports the EUR amount used in the calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e310e3b4832b8078ec3e3f4dc5a8