### PR TITLE
Handle electric vehicles excise

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -323,8 +323,12 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
     duty_rub = duty_eur * eur_rate
 
     # Акциз
-    excise_rate = _excise_hp_rate(hp)
-    excise_rub = hp * excise_rate
+    if fuel.lower() == "электро":
+        excise_rate = 0
+        excise_rub = 0
+    else:
+        excise_rate = _excise_hp_rate(hp)
+        excise_rub = hp * excise_rate
 
     # НДС
     vat_rub = (value_rub + duty_rub + excise_rub) * 0.20

--- a/tests/test_calc_min.py
+++ b/tests/test_calc_min.py
@@ -65,3 +65,17 @@ def test_ul_5_7_diesel_brackets():
 def test_pick_fl_under3_rule_negative():
     with pytest.raises(ValueError):
         pick_fl_under3_rule_by_value_eur(-100)
+
+
+def test_ul_electric_excise_zero():
+    res = calculate_company(
+        customs_value=30000,
+        currency="USD",
+        engine_cc=0,
+        production_year=2024,
+        fuel="Электро",
+        hp=200,
+    )
+    assert res["excise_rub"] == 0
+    expected_vat = (res["customs_value_rub"] + res["duty_rub"]) * 0.20
+    assert math.isclose(res["vat_rub"], expected_vat, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- Avoid computing excise for electric vehicles and ensure VAT uses the adjusted amount
- Test zero excise and VAT calculation for electric vehicles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e311e234832b9569823a2427ab78