### PR TITLE
Use package-relative imports for startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Install dependencies and run the bot:
 
 ```
 pip install -r requirements.txt
-python bot_alista/main.py
+python -m bot_alista.main
 ```
+
+Run the bot as a module (`python -m bot_alista.main`) so that package-relative imports
+resolve correctly.
 
 The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.
 

--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,7 +1,8 @@
 import asyncio
 from aiogram import Bot, Dispatcher
-from config import TOKEN
-from handlers import menu, calculate, navigation, request
+
+from .config import TOKEN
+from .handlers import menu, calculate, navigation, request
 
 
 async def main():

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -9,10 +9,10 @@ from aiogram import F, Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 
-from states import CalculationStates
-from keyboards.navigation import back_menu
-from utils.reset import reset_to_menu
-from constants import (
+from ..states import CalculationStates
+from ..keyboards.navigation import back_menu
+from ..utils.reset import reset_to_menu
+from ..constants import (
     CURRENCY_CODES,
     PROMPT_PERSON,
     ERROR_PERSON,
@@ -36,12 +36,12 @@ from constants import (
     BTN_BACK,
     ERROR_RATE,
 )
-from bot_alista.services.rates import (
+from ..services.rates import (
     get_cached_rates,
     validate_or_prompt_rate,
 )
 from tariff_engine import calc_breakdown_rules
-from bot_alista.formatting import format_result_message
+from ..formatting import format_result_message
 
 
 router = Router()

--- a/bot_alista/handlers/menu.py
+++ b/bot_alista/handlers/menu.py
@@ -1,7 +1,7 @@
 from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from keyboards.main_menu import main_menu
+from ..keyboards.main_menu import main_menu
 
 router = Router()
 

--- a/bot_alista/handlers/navigation.py
+++ b/bot_alista/handlers/navigation.py
@@ -1,7 +1,7 @@
 from aiogram import Router, types, F
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
-from utils.reset import reset_to_menu
+from ..utils.reset import reset_to_menu
 
 router = Router()
 

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -3,11 +3,11 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 
-from states import RequestStates
-from keyboards.navigation import back_menu
-from utils.reset import reset_to_menu
-from services.email import send_email
-from config import EMAIL_TO
+from ..states import RequestStates
+from ..keyboards.navigation import back_menu
+from ..utils.reset import reset_to_menu
+from ..services.email import send_email
+from ..config import EMAIL_TO
 
 router = Router()
 

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -1,14 +1,11 @@
 """Entry point for running the Telegram bot."""
 
 import asyncio
-import sys
-import os
 import logging
 
-logging.basicConfig(level=logging.INFO)
+from .bot import main as run_bot
 
-sys.path.append(os.path.dirname(__file__))
-from bot_alista.bot import main as run_bot
+logging.basicConfig(level=logging.INFO)
 
 
 if __name__ == "__main__":

--- a/bot_alista/services/email.py
+++ b/bot_alista/services/email.py
@@ -6,7 +6,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from config import EMAIL_LOGIN, EMAIL_PASSWORD, SMTP_SERVER, SMTP_PORT
+from ..config import EMAIL_LOGIN, EMAIL_PASSWORD, SMTP_SERVER, SMTP_PORT
 
 
 def send_email(

--- a/bot_alista/utils/reset.py
+++ b/bot_alista/utils/reset.py
@@ -1,5 +1,5 @@
 from aiogram.fsm.context import FSMContext
-from keyboards.main_menu import main_menu
+from ..keyboards.main_menu import main_menu
 from aiogram import types
 
 async def reset_to_menu(message: types.Message, state: FSMContext):


### PR DESCRIPTION
## Summary
- switch bot entry point to package-relative imports
- document running the bot via `python -m bot_alista.main`
- make internal modules use relative imports for stable module startup

## Testing
- `pytest`
- `python -m bot_alista.main` *(fails: Token is invalid!)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e7fedbc4832ba693f6ab87e214f0