### PR TITLE
Fix SMTP server env var name and documentation

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 BOT_TOKEN = "8318772952:AAGGMwcRSbbd42YuR-rkUkA53Qf6DHTQJTs"
 
 # SMTP server configuration
-SMTP_SERVE = "smtp.yandex.ru"
+SMTP_SERVER = "smtp.yandex.ru"
 SMTP_PORT = 465
 EMAIL_LOGIN = "korol.artur.2002@yandex.ru"
 EMAIL_PASSWORD = "attqhdcqxfdkepcm"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cp .env.example .env
 Required variables:
 
 - `BOT_TOKEN` – Telegram bot token.
-- `SMTP_SERVER` – SMTP server host.
+- `SMTP_SERVER` – SMTP server host (use `SMTP_SERVER`, not `SMTP_SERVE`).
 - `SMTP_PORT` – SMTP port.
 - `EMAIL_LOGIN` – SMTP account username.
 - `EMAIL_PASSWORD` – SMTP account password.


### PR DESCRIPTION
## Summary
- rename SMTP_SERVE to SMTP_SERVER in .env
- clarify README to use SMTP_SERVER (not SMTP_SERVE)

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python - <<'PY'
import sys
sys.path.append('bot_alista')
from services.email import send_email
import config
result = send_email(config.EMAIL_TO, 'Test Email', 'This is a test email.')
print('send_email returned', result)
PY` *(network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e80310fc832b8ffa3bcd718912db