### PR TITLE
Refactor bot startup to defer token checks

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,11 +1,13 @@
-import asyncio
 from aiogram import Bot, Dispatcher
 
 from .config import TOKEN
 from .handlers import menu, calculate, navigation, request
 
 
-async def main():
+async def main() -> None:
+    """Start polling if the bot token is configured."""
+    if not TOKEN:
+        raise RuntimeError("BOT_TOKEN is not configured. Check your .env file")
     bot = Bot(token=TOKEN)
     dp = Dispatcher()
 
@@ -15,7 +17,3 @@ async def main():
     dp.include_router(request.router)
 
     await dp.start_polling(bot)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/bot_alista/config.py
+++ b/bot_alista/config.py
@@ -19,7 +19,5 @@ EMAIL_LOGIN = os.getenv("EMAIL_LOGIN")
 EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
 EMAIL_TO = os.getenv("EMAIL_TO")
 
-# Fail fast if the mandatory token is missing to help diagnose
-# misconfigured environments early.
-if not TOKEN:
-    raise RuntimeError("BOT_TOKEN is not configured. Check your .env file")
+# Optional: other modules may import this file without a configured token.
+# The bot itself validates the presence of the token at startup.

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -9,4 +9,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 if __name__ == "__main__":
-    asyncio.run(run_bot())
+    try:
+        asyncio.run(run_bot())
+    except RuntimeError as exc:  # Missing configuration
+        logging.error("%s", exc)


### PR DESCRIPTION
## Summary
- Avoid raising errors on import by removing fail-fast token check in `config.py`
- Validate bot token at runtime and drop redundant start logic in `bot.py`
- Add graceful error handling when launching via `main.py`

## Testing
- `pytest -q`
- `python -m bot_alista.main` *(fails with config warning as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f220d3e0832b8d534b2c08f39564