### PR TITLE
Allow loading environment variables from external file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 ## Configuration
 
-The bot reads configuration from environment variables. Create a `.env` file using `.env.example` as a template and fill in your values:
+The bot reads configuration from environment variables. For local development you can create a `.env` file using `.env.example` as a template and fill in your values:
 
 ```
 cp .env.example .env
 # edit .env
 ```
+
+If you keep the `.env` file outside the repository (e.g. on a server), set the `ENV_FILE` environment variable to its path so that the bot can load it automatically. Alternatively, provide all variables directly in the server environment.
 
 Required variables:
 
@@ -28,7 +30,7 @@ python -m bot_alista.main
 Run the bot as a module (`python -m bot_alista.main`) so that package-relative imports
 resolve correctly.
 
-The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.
+The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file or point `ENV_FILE` to an external location.
 
 ## Customs and duty calculations
 

--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -7,7 +7,7 @@ from .handlers import menu, calculate, navigation, request
 async def main() -> None:
     """Start polling if the bot token is configured."""
     if not TOKEN:
-        raise RuntimeError("BOT_TOKEN is not configured. Check your .env file")
+        raise RuntimeError("BOT_TOKEN is not configured. Check your environment variables.")
     bot = Bot(token=TOKEN)
     dp = Dispatcher()
 

--- a/bot_alista/config.py
+++ b/bot_alista/config.py
@@ -1,14 +1,16 @@
 import os
-from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
-# Load the .env file located in the project root regardless of the
-# current working directory. This avoids situations where environment
-# variables are not loaded when the script is executed from another
-# folder.
-env_path = Path(__file__).resolve().parent.parent / ".env"
-load_dotenv(env_path)
+# Attempt to load environment variables from a file. If the ENV_FILE
+# variable is set, use it; otherwise search for a ".env" file in the
+# current working directory tree. Missing files are ignored so that
+# configuration can also be supplied via the server environment.
+env_file = os.getenv("ENV_FILE")
+if env_file:
+    load_dotenv(env_file)
+else:
+    load_dotenv(find_dotenv())
 
 TOKEN = os.getenv("BOT_TOKEN")
 


### PR DESCRIPTION
## Summary
- allow specifying external .env file via `ENV_FILE`
- clarify token error message to mention environment variables
- document `ENV_FILE` usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2f6650794832bb8f24ea77e86836b