### PR TITLE
Handle script execution for bot entrypoint

### DIFF
--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -3,13 +3,30 @@
 import asyncio
 import logging
 
-from .bot import main as run_bot
+# When the module is executed as ``python -m bot_alista.main`` the
+# package-relative import below works.  However, when run directly as a
+# script (e.g. ``python bot_alista/main.py``) the relative import fails.
+# To make local development and "run" buttons in editors work, fall back
+# to an absolute import in that scenario.
+if __package__:
+    from .bot import main as run_bot
+else:  # pragma: no cover - executed when running as a script
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from bot_alista.bot import main as run_bot
 
 logging.basicConfig(level=logging.INFO)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the bot and report missing configuration."""
     try:
         asyncio.run(run_bot())
     except RuntimeError as exc:  # Missing configuration
         logging.error("%s", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `bot_alista/main.py` to be executed directly by falling back to an absolute import
- add `main()` wrapper and configuration error reporting

## Testing
- `python bot_alista/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a30ec32af8832b9e7345a6f296980d