### PR TITLE
Add exit message handler

### DIFF
--- a/bot_alista/handlers/navigation.py
+++ b/bot_alista/handlers/navigation.py
@@ -17,3 +17,10 @@ async def cancel_command(message: types.Message, state: FSMContext) -> None:
 async def nav_main_menu(message: types.Message, state: FSMContext) -> None:
     """Return to main menu when user presses navigation buttons."""
     await reset_to_menu(message, state)
+
+
+@router.message(F.text == "❌ Выход")
+async def exit_to_menu(message: types.Message, state: FSMContext) -> None:
+    """Handle exit button by resetting state and sending a farewell."""
+    await reset_to_menu(message, state)
+    await message.answer("До встречи!")


### PR DESCRIPTION
## Summary
- Add handler for the "❌ Выход" button to reset state and send a farewell

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a311fdae48832b9ff5d512e22a150b