### PR TITLE
feat: use async currency rate fetching

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -349,7 +349,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         manual_rates = data.get("manual_rates", {})
         needed = {currency_code, "EUR"}
         try:
-            rates = get_cached_rates(decl_date, codes=("EUR", "USD", "JPY", "CNY"))
+            rates = await get_cached_rates(decl_date, codes=("EUR", "USD", "JPY", "CNY"))
             customs_value_rub = amount * rates[currency_code]
         except Exception:
             missing = [c for c in needed if c not in manual_rates]

--- a/bot_alista/services/rates.py
+++ b/bot_alista/services/rates.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 from datetime import date
 from pathlib import Path
 from typing import Dict, Iterable, Literal
+import asyncio
 import json
-import time
 import xml.etree.ElementTree as ET
 
-import requests
+import aiohttp
 
 SUPPORTED_CODES: tuple[str, ...] = ("EUR", "USD", "JPY", "CNY")
 CBR_URL = "https://www.cbr.ru/scripts/XML_daily.asp"
@@ -29,7 +29,7 @@ def _cache_file(for_date: date) -> Path:
     return base / f"{for_date.isoformat()}.json"
 
 
-def _fetch_cbr_rates(
+async def _fetch_cbr_rates(
     for_date: date,
     codes: Iterable[str] = SUPPORTED_CODES,
     retries: int = 3,
@@ -48,14 +48,15 @@ def _fetch_cbr_rates(
 
     for attempt in range(1, retries + 1):
         try:
-            resp = requests.get(CBR_URL, params=params, timeout=timeout)
-            resp.raise_for_status()
-            resp.encoding = "windows-1251"
-            root = ET.fromstring(resp.text)
-        except (requests.RequestException, ET.ParseError) as exc:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(CBR_URL, params=params, timeout=timeout) as resp:
+                    resp.raise_for_status()
+                    text = await resp.text(encoding="windows-1251")
+            root = ET.fromstring(text)
+        except (aiohttp.ClientError, asyncio.TimeoutError, ET.ParseError) as exc:
             if attempt == retries:
                 raise RuntimeError("Ошибка получения данных ЦБ РФ") from exc
-            time.sleep(attempt)
+            await asyncio.sleep(attempt)
             continue
 
         rates: Dict[str, float] = {}
@@ -83,7 +84,7 @@ def _fetch_cbr_rates(
 # Публичное API
 # ---------------------------------------------------------------------------
 
-def get_cbr_rate(
+async def get_cbr_rate(
     for_date: date,
     code: Literal["EUR", "USD", "JPY", "CNY"],
     retries: int = 3,
@@ -97,10 +98,11 @@ def get_cbr_rate(
     :param timeout: таймаут запроса в секундах
     :return: курс в рублях за единицу валюты
     """
-    return _fetch_cbr_rates(for_date, [code], retries=retries, timeout=timeout)[code]
+    rates = await _fetch_cbr_rates(for_date, [code], retries=retries, timeout=timeout)
+    return rates[code]
 
 
-def get_cached_rates(
+async def get_cached_rates(
     for_date: date,
     codes: Iterable[str] = SUPPORTED_CODES,
     retries: int = 3,
@@ -122,7 +124,7 @@ def get_cached_rates(
         except json.JSONDecodeError:
             pass  # повреждённый кэш – перезапишем ниже
 
-    fresh = _fetch_cbr_rates(for_date, SUPPORTED_CODES, retries=retries, timeout=timeout)
+    fresh = await _fetch_cbr_rates(for_date, SUPPORTED_CODES, retries=retries, timeout=timeout)
     payload = {
         "date": for_date.isoformat(),
         "provider": "CBR",
@@ -134,17 +136,18 @@ def get_cached_rates(
     return {code: fresh[code] for code in codes}
 
 
-def get_cached_rate(
+async def get_cached_rate(
     for_date: date,
     code: Literal["EUR", "USD", "JPY", "CNY"],
     retries: int = 3,
     timeout: float = 5.0,
 ) -> float:
     """Возвращает курс валюты из кэша или с запросом в ЦБ РФ."""
-    return get_cached_rates(for_date, [code], retries=retries, timeout=timeout)[code]
+    rates = await get_cached_rates(for_date, [code], retries=retries, timeout=timeout)
+    return rates[code]
 
 
-def currency_to_rub(
+async def currency_to_rub(
     amount: float,
     code: Literal["EUR", "USD", "JPY", "CNY"],
     for_date: date | None = None,
@@ -158,8 +161,42 @@ def currency_to_rub(
     """
     if for_date is None:
         for_date = date.today()
-    rate = get_cached_rate(for_date, code)
+    rate = await get_cached_rate(for_date, code)
     return amount * rate
+
+
+# ---------------------------------------------------------------------------
+# Синхронные обёртки
+# ---------------------------------------------------------------------------
+
+
+def get_cached_rates_sync(
+    for_date: date,
+    codes: Iterable[str] = SUPPORTED_CODES,
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> Dict[str, float]:
+    """Синхронная обёртка вокруг :func:`get_cached_rates`."""
+    return asyncio.run(get_cached_rates(for_date, codes, retries=retries, timeout=timeout))
+
+
+def get_cached_rate_sync(
+    for_date: date,
+    code: Literal["EUR", "USD", "JPY", "CNY"],
+    retries: int = 3,
+    timeout: float = 5.0,
+) -> float:
+    """Синхронная обёртка вокруг :func:`get_cached_rate`."""
+    return asyncio.run(get_cached_rate(for_date, code, retries=retries, timeout=timeout))
+
+
+def currency_to_rub_sync(
+    amount: float,
+    code: Literal["EUR", "USD", "JPY", "CNY"],
+    for_date: date | None = None,
+) -> float:
+    """Синхронная обёртка вокруг :func:`currency_to_rub`."""
+    return asyncio.run(currency_to_rub(amount, code, for_date))
 
 
 def validate_or_prompt_rate(user_input: str) -> float:
@@ -187,10 +224,10 @@ def validate_or_prompt_rate(user_input: str) -> float:
 
 if __name__ == "__main__":
     today = date.today()
-    rates = get_cached_rates(today)
+    rates = asyncio.run(get_cached_rates(today))
     print(f"Курсы ЦБ РФ на {today}:")
     for code, rate in rates.items():
         print(f"  {code}: {rate:.4f} руб.")
     amount = 100
-    rub = currency_to_rub(amount, "USD", today)
+    rub = asyncio.run(currency_to_rub(amount, "USD", today))
     print(f"{amount} USD = {rub:.2f} RUB")

--- a/calculator.py
+++ b/calculator.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 import math
 
-from bot_alista.services.rates import get_cached_rate
+from bot_alista.services.rates import get_cached_rate_sync as get_cached_rate
 
 # ---------------------------------------------------------------------------
 # Вспомогательные структуры и таблицы тарифов

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram>=3.0.0
 python-dotenv
 requests
 fpdf2
+aiohttp


### PR DESCRIPTION
## Summary
- fetch CBR exchange rates with aiohttp instead of blocking requests
- expose async rate helpers and synchronous wrappers for calculators
- await rate lookup in vehicle cost handler
- add aiohttp to project requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a447c88f5c832baf72c9d89db2f0c9