### PR TITLE
Add configuration validation and startup check

### DIFF
--- a/bot_alista/config.py
+++ b/bot_alista/config.py
@@ -1,6 +1,7 @@
 import os
+import re
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 # Attempt to load environment variables from a file. If the ENV_FILE
 # variable is set, use it; otherwise search for a ".env" file in the
@@ -16,10 +17,52 @@ TOKEN = os.getenv("BOT_TOKEN")
 
 # Email configuration
 SMTP_SERVER = os.getenv("SMTP_SERVER")
-SMTP_PORT = int(os.getenv("SMTP_PORT", 465))
+try:
+    SMTP_PORT = int(os.getenv("SMTP_PORT", "465"))
+except ValueError:  # Non-integer port
+    SMTP_PORT = None
 EMAIL_LOGIN = os.getenv("EMAIL_LOGIN")
 EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
 EMAIL_TO = os.getenv("EMAIL_TO")
 
+_EMAIL_RE = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
+_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]+$")
+
+
+def validate_config() -> None:
+    """Ensure required settings are present and correctly formatted.
+
+    Raises:
+        RuntimeError: If any required configuration value is missing or
+            malformed.
+    """
+
+    missing = []
+
+    if not TOKEN or not _TOKEN_RE.match(TOKEN):
+        missing.append("BOT_TOKEN")
+
+    if not SMTP_SERVER:
+        missing.append("SMTP_SERVER")
+
+    if SMTP_PORT is None or SMTP_PORT <= 0:
+        missing.append("SMTP_PORT")
+
+    if not EMAIL_LOGIN or not _EMAIL_RE.match(EMAIL_LOGIN):
+        missing.append("EMAIL_LOGIN")
+
+    if not EMAIL_PASSWORD:
+        missing.append("EMAIL_PASSWORD")
+
+    if not EMAIL_TO or not _EMAIL_RE.match(EMAIL_TO):
+        missing.append("EMAIL_TO")
+
+    if missing:
+        raise RuntimeError(
+            f"Invalid or missing configuration for: {', '.join(missing)}"
+        )
+
+
 # Optional: other modules may import this file without a configured token.
-# The bot itself validates the presence of the token at startup.
+# validate_config() should be called before features that require these
+# settings are used.

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import logging
+import sys
 
 from .bot import main as run_bot
+from .config import validate_config
 
 logging.basicConfig(level=logging.INFO)
 
@@ -11,9 +13,11 @@ logging.basicConfig(level=logging.INFO)
 def main() -> None:
     """Run the bot and report missing configuration."""
     try:
+        validate_config()
         asyncio.run(run_bot())
     except RuntimeError as exc:  # Missing configuration
         logging.error("%s", exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `validate_config` helper to ensure BOT_TOKEN, SMTP credentials, and recipient email are present and well-formed
- Validate configuration before starting the bot, logging and exiting on errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a447cbedac832baf4e5225618bdbad