### PR TITLE
Use constants for main menu labels

### DIFF
--- a/bot_alista/constants.py
+++ b/bot_alista/constants.py
@@ -1,10 +1,11 @@
 from typing import Literal
 
 # Button labels
-BTN_CALC = "📊 Рассчитать"
+BTN_CALC = "📊 Рассчитать стоимость таможенной очистки"
+BTN_LEAD = "📝 Оставить заявку"
+BTN_EXIT = "❌ Выход"
 BTN_BACK = "⬅ Назад"
 BTN_FAQ = "ℹ️ FAQ"
-BTN_LEAD = "📞 Заявка"
 BTN_LAST = "🧾 Последний расчёт"
 BTN_NEW = "🔁 Новый расчёт"
 BTN_SEND = "📩 Отправить менеджеру"

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -35,6 +35,7 @@ from ..constants import (
     BTN_AGE_OVER3_NO,
     BTN_BACK,
     ERROR_RATE,
+    BTN_CALC,
 )
 from ..services.rates import (
     get_cached_rates,
@@ -121,7 +122,7 @@ async def _check_nav(
 # ---------------------------------------------------------------------------
 
 
-@router.message(F.text == "📊 Рассчитать стоимость таможенной очистки")
+@router.message(F.text == BTN_CALC)
 async def start_calculation(message: types.Message, state: FSMContext) -> None:
     await state.set_state(CalculationStates.person_type)
     await message.answer(PROMPT_PERSON, reply_markup=_person_type_kb())

--- a/bot_alista/handlers/navigation.py
+++ b/bot_alista/handlers/navigation.py
@@ -2,6 +2,7 @@ from aiogram import Router, types, F
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from ..utils.reset import reset_to_menu
+from ..constants import BTN_EXIT, BTN_BACK
 
 router = Router()
 
@@ -13,13 +14,13 @@ async def cancel_command(message: types.Message, state: FSMContext) -> None:
     await message.answer("❌ Действие отменено")
 
 
-@router.message(StateFilter(None), F.text.in_({"🏠 Главное меню", "⬅ Назад"}))
+@router.message(StateFilter(None), F.text.in_({"🏠 Главное меню", BTN_BACK}))
 async def nav_main_menu(message: types.Message, state: FSMContext) -> None:
     """Return to main menu when user presses navigation buttons."""
     await reset_to_menu(message, state)
 
 
-@router.message(F.text == "❌ Выход")
+@router.message(F.text == BTN_EXIT)
 async def exit_to_menu(message: types.Message, state: FSMContext) -> None:
     """Handle exit button by resetting state and sending a farewell."""
     await reset_to_menu(message, state)

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -8,10 +8,11 @@ from ..keyboards.navigation import back_menu
 from ..utils.reset import reset_to_menu
 from ..services.email import send_email
 from ..config import EMAIL_TO
+from ..constants import BTN_LEAD
 
 router = Router()
 
-@router.message(F.text == "📝 Оставить заявку")
+@router.message(F.text == BTN_LEAD)
 async def start_request(message: types.Message, state: FSMContext) -> None:
     """Initiate the request conversation by asking for contact details."""
     await state.set_state(RequestStates.contact)

--- a/bot_alista/keyboards/main_menu.py
+++ b/bot_alista/keyboards/main_menu.py
@@ -1,10 +1,12 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
+from ..constants import BTN_CALC, BTN_LEAD, BTN_EXIT
+
 def main_menu():
     kb = [
-        [KeyboardButton(text="📊 Рассчитать стоимость таможенной очистки")],
-        [KeyboardButton(text="📝 Оставить заявку")],
-        [KeyboardButton(text="❌ Выход")]
+        [KeyboardButton(text=BTN_CALC)],
+        [KeyboardButton(text=BTN_LEAD)],
+        [KeyboardButton(text=BTN_EXIT)]
     ]
     return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)
 


### PR DESCRIPTION
## Summary
- Define button text constants for calculation, request, and exit actions
- Use these constants in main menu and relevant handlers
- Centralize button labels to keep menu options consistent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a447cef490832b9fbd7ca6c36efb3e