### PR TITLE
Use tariff_engine for clearance fee and drop constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to l
 - Rules are loaded from `bot_alista/data/rules/russia_auto_import_rules_2025_formulas.csv` (UTF-8-SIG). If the file is missing, minimal fallback rules are used.
 - Individuals (personal): STP unified duty from CSV; VAT and excise are embedded.
 - Companies (commercial): duty = max(ad valorem, min €/cc) or specific €/cc, plus excise (rub/hp) and VAT 20%.
-- Clearance fee ladder updated for 2025 bands.
+- Clearance fee ladder updated for 2025 bands. Use
+  `tariff_engine.calc_clearance_fee_rub` to obtain the customs clearance fee
+  instead of a fixed constant.
 - Utilization fee uses factual age from production year; for FL duty bucket, the user selects ≤3 or >3 years.
 

--- a/bot_alista/tariff/personal_rates.py
+++ b/bot_alista/tariff/personal_rates.py
@@ -57,9 +57,9 @@ PERSONAL_RATES: Dict[str, Tuple[PersonalDutyRate, ...]] = {
     ),
 }
 
-# Customs clearance fee (RUB) to display and add for individuals.
-# Adjust if your reference differs.
-CUSTOMS_CLEARANCE_FEE_RUB: float = 4269.0
+# Customs clearance fee is calculated via
+# ``tariff_engine.calc_clearance_fee_rub``.  No fixed constant is stored
+# here to avoid drift from the authoritative fee ladder.
 
 
 def _age_bucket(age_years: float) -> str:

--- a/calculator.py
+++ b/calculator.py
@@ -13,6 +13,7 @@ from typing import Dict
 import math
 
 from bot_alista.services.rates import get_cached_rate_sync as get_cached_rate
+from bot_alista.tariff_engine import calc_clearance_fee_rub
 
 # ---------------------------------------------------------------------------
 # Вспомогательные структуры и таблицы тарифов
@@ -114,15 +115,6 @@ UTIL_COEFF_UL = {
     "over_10": 6.73,
 }
 
-CLEARANCE_FEE_TABLE = [
-    (200_000, 1067),
-    (450_000, 2134),
-    (1_200_000, 4269),
-    (3_000_000, 11746),
-    (5_000_000, 16524),
-    (7_000_000, 20000),
-    (math.inf, 30000),
-]
 
 # ФЛ ≤3 лет — таблица по ТАМОЖЕННОЙ СТОИМОСТИ (EUR), не по объёму!
 FL_STP_UNDER3_BY_VALUE_EUR = [
@@ -260,7 +252,7 @@ def calculate_individual(*, customs_value: float, currency: Currency, engine_cc:
 
     util_coeff = UTIL_COEFF_FL["under_3" if age_cat == "under_3" else "over_3"]
     util_rub = UTIL_BASE_UL * util_coeff
-    fee_rub = _pick_rate(CLEARANCE_FEE_TABLE, value_rub)
+    fee_rub = calc_clearance_fee_rub(value_rub)
     trace.append(f"Сбор за оформление: {fee_rub} руб")
     total_rub = duty_rub + util_rub + fee_rub
 
@@ -338,7 +330,7 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
     util_rub = UTIL_BASE_UL * util_coeff
 
     # Сбор за оформление
-    fee_rub = _pick_rate(CLEARANCE_FEE_TABLE, value_rub)
+    fee_rub = calc_clearance_fee_rub(value_rub)
     trace.append(f"Сбор за оформление: {fee_rub} руб")
 
     total_rub = duty_rub + excise_rub + vat_rub + util_rub + fee_rub


### PR DESCRIPTION
## Summary
- Remove unused CUSTOMS_CLEARANCE_FEE_RUB constant from personal rates
- Delegate clearance fee calculations to `tariff_engine.calc_clearance_fee_rub`
- Update docs and tests to reference the function instead of a fixed constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44dc63f9c832ba02685c22f55f597