### PR TITLE
Remove legacy calculator formatting functions

### DIFF
--- a/bot_alista/formatting.py
+++ b/bot_alista/formatting.py
@@ -53,6 +53,16 @@ def format_result_message(
     age_info = meta.get("age_info", "")
     person_usage = meta.get("person_usage", "")
     extra_notes = meta.get("extra_notes", [])
+    trace = (
+        meta.get("trace")
+        or core.get("trace")
+        or br.get("trace")
+    )
+    if trace:
+        if isinstance(trace, list):
+            extra_notes.extend(trace[:10])
+        else:
+            extra_notes.append(str(trace))
 
     lines: list[str] = []
     lines.append("📦 Расчёт таможенных платежей:\n")

--- a/calculator.py
+++ b/calculator.py
@@ -359,42 +359,7 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
     }
 
 
-# ---------------------------------------------------------------------------
-# Формирование текстовых ответов для бота
-# ---------------------------------------------------------------------------
-
-
-def format_individual_result(data: Dict[str, float]) -> str:
-    base = (
-        "📦 Таможенная стоимость: " + _format_money(data["customs_value_rub"]) + " ₽\n"
-        "🛃 СТП: " + _format_money(data["duty_rub"]) + " ₽\n"
-        "♻️ Утильсбор: " + _format_money(data["util_rub"]) + " ₽\n"
-        "📄 Сбор за оформление: " + _format_money(data.get("clearance_fee_rub", 0)) + " ₽\n"
-        "✅ Итоговая сумма: " + _format_money(data["total_rub"]) + " ₽"
-    )
-    if trace := data.get("trace"):
-        base += "\n" + "\n".join(trace[:10])
-    return base
-
-
-def format_company_result(data: Dict[str, float]) -> str:
-    base = (
-        "📦 Таможенная стоимость: " + _format_money(data["customs_value_rub"]) + " ₽\n"
-        "🛃 Пошлина: " + _format_money(data["duty_rub"]) + " ₽\n"
-        "🚗 Акциз: " + _format_money(data["excise_rub"]) + " ₽\n"
-        "💰 НДС: " + _format_money(data["vat_rub"]) + " ₽\n"
-        "♻️ Утилизационный сбор: " + _format_money(data["util_rub"]) + " ₽\n"
-        "📄 Сбор за оформление: " + _format_money(data["clearance_fee_rub"]) + " ₽\n"
-        "✅ Итоговая сумма: " + _format_money(data["total_rub"]) + " ₽"
-    )
-    if trace := data.get("trace"):
-        base += "\n" + "\n".join(trace[:10])
-    return base
-
-
 __all__ = [
     "calculate_individual",
     "calculate_company",
-    "format_individual_result",
-    "format_company_result",
 ]


### PR DESCRIPTION
## Summary
- drop deprecated `format_individual_result` and `format_company_result`
- route result formatting through `bot_alista.formatting.format_result_message`
- include optional trace lines when formatting results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44db33c24832b9c46d182c86b4b11