### PR TITLE
Validate calculation inputs

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -194,7 +194,10 @@ async def get_amount(message: types.Message, state: FSMContext) -> None:
         return
     try:
         amount = float(message.text.replace(",", "."))
-    except Exception:
+    except ValueError:
+        await message.answer(ERROR_AMOUNT)
+        return
+    if amount <= 0:
         await message.answer(ERROR_AMOUNT)
         return
     await state.update_data(amount=amount)
@@ -220,7 +223,10 @@ async def get_engine(message: types.Message, state: FSMContext) -> None:
         return
     try:
         engine = int(message.text)
-    except Exception:
+    except ValueError:
+        await message.answer(ERROR_ENGINE)
+        return
+    if engine <= 0:
         await message.answer(ERROR_ENGINE)
         return
     await state.update_data(engine=engine)
@@ -243,7 +249,10 @@ async def get_power(message: types.Message, state: FSMContext) -> None:
             power_hp = power_kw * 1.35962
         else:
             power_hp = float("".join(c for c in val if c.isdigit() or c == "."))
-    except Exception:
+    except ValueError:
+        await message.answer(ERROR_POWER)
+        return
+    if power_hp <= 0:
         await message.answer(ERROR_POWER)
         return
     await state.update_data(power_hp=round(power_hp, 1))
@@ -259,9 +268,11 @@ async def get_year(message: types.Message, state: FSMContext) -> None:
         return
     try:
         year = int(message.text)
-        if year < 1980 or year > date.today().year:
-            raise ValueError
-    except Exception:
+    except ValueError:
+        await message.answer(ERROR_YEAR)
+        return
+    current_year = date.today().year
+    if year < 1980 or year > current_year:
         await message.answer(ERROR_YEAR)
         return
     await state.update_data(year=year)


### PR DESCRIPTION
## Summary
- Narrow exception handling to `ValueError` in calculation handlers
- Reject non-positive or out-of-range values for amount, engine, power and year inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4512c8b24832b84c620dea5760a2c