### PR TITLE
Optimize rate fetching for calculations

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -350,7 +350,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         manual_rates = data.get("manual_rates", {})
         needed = {currency_code, "EUR"}
         try:
-            rates = await get_cached_rates(decl_date, codes=("EUR", "USD", "JPY", "CNY"))
+            rates = await get_cached_rates(decl_date, codes=needed)
             customs_value_rub = amount * rates[currency_code]
         except Exception:
             missing = [c for c in needed if c not in manual_rates]

--- a/tests/test_needed_rates.py
+++ b/tests/test_needed_rates.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from types import SimpleNamespace
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from bot_alista.handlers.calculate import _run_calculation
+
+def test_run_calculation_requests_only_needed_codes(monkeypatch):
+    state_data = {
+        "car_type": "Бензин",
+        "currency_code": "USD",
+        "amount": 1000.0,
+        "engine": 0,
+        "power_hp": 0,
+        "year": 2020,
+    }
+
+    class DummyState:
+        async def get_data(self):
+            return state_data
+
+        async def update_data(self, **kwargs):
+            state_data.update(kwargs)
+
+        async def set_state(self, state):
+            state_data["state"] = state
+
+    captured_codes = []
+
+    async def fake_get_cached_rates(for_date, codes, retries=3, timeout=5.0):
+        captured_codes.append(set(codes))
+        return {code: 1.0 for code in codes}
+
+    monkeypatch.setattr(
+        "bot_alista.handlers.calculate.get_cached_rates", fake_get_cached_rates
+    )
+    async def fake_reset_to_menu(*args, **kwargs):
+        return None
+    monkeypatch.setattr(
+        "bot_alista.handlers.calculate.reset_to_menu", fake_reset_to_menu
+    )
+    monkeypatch.setattr(
+        "bot_alista.handlers.calculate.calc_breakdown_rules",
+        lambda **kwargs: {"breakdown": {"customs_value_rub": 100, "duty_rub": 10, "vat_rub": 0, "excise_rub": 0, "total_rub": 10}, "notes": []},
+    )
+    monkeypatch.setattr(
+        "bot_alista.handlers.calculate.format_result_message", lambda **kwargs: "ok"
+    )
+
+    async def dummy_answer(*args, **kwargs):
+        pass
+
+    dummy_message = SimpleNamespace(answer=dummy_answer)
+
+    asyncio.run(_run_calculation(DummyState(), dummy_message))
+
+    assert captured_codes == [{"USD", "EUR"}]


### PR DESCRIPTION
## Summary
- Request only needed currency codes during customs calculation
- Add test ensuring rate fetching limited to required codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a451325a64832b9d17566a1b1300e8