### PR TITLE
Clear webhook before polling

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -9,6 +9,7 @@ async def main() -> None:
     if not TOKEN:
         raise RuntimeError("BOT_TOKEN is not configured. Check your environment variables.")
     bot = Bot(token=TOKEN)
+    await bot.delete_webhook(drop_pending_updates=True)
     dp = Dispatcher()
 
     dp.include_router(menu.router)


### PR DESCRIPTION
## Summary
- ensure polling starts without webhook conflicts by deleting webhook with pending updates dropped

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a59dd9ba1c832b839c54287e12939d