### PR TITLE
Add single instance lock for polling process

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ resolve correctly.
 
 The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file or point `ENV_FILE` to an external location.
 
+## Single instance lock
+
+Only one polling process should run at a time. The bot creates a lock file at `/tmp/alistabot.lock` when it starts. If another process is already running, startup fails with an error. To override a stale lock (for example after a crash), delete the lock file or start the bot with the `--force` flag:
+
+```
+python -m bot_alista.main --force
+```
+
+If the process exits abnormally (e.g. is killed), remove `/tmp/alistabot.lock` to allow a clean restart.
+
 ## Customs and duty calculations
 
 - Customs value can now be entered in EUR / USD / JPY / CNY. CBR daily rates are fetched by declaration date; if unavailable, the bot asks for manual rates.

--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,11 +1,53 @@
+"""Bot startup and locking utilities."""
+
 from aiogram import Bot, Dispatcher
+
+import os
+import atexit
 
 from .config import TOKEN
 from .handlers import menu, calculate, navigation, request
 
+LOCKFILE = "/tmp/alistabot.lock"
 
-async def main() -> None:
-    """Start polling if the bot token is configured."""
+
+def _acquire_lock(force: bool) -> None:
+    """Create a lock file to prevent multiple polling processes.
+
+    If the lock file already exists and ``force`` is ``False``, a ``RuntimeError``
+    is raised. When ``force`` is ``True`` a stale lock file is removed.
+    The lock file is removed automatically at process exit, but if the process
+    is killed it might persist and must be deleted manually.
+    """
+
+    if os.path.exists(LOCKFILE):
+        if force:
+            try:
+                os.remove(LOCKFILE)
+            except OSError:
+                pass
+        else:
+            raise RuntimeError(
+                f"Another instance appears to be running (lock: {LOCKFILE})."
+            )
+
+    with open(LOCKFILE, "w") as lock:
+        lock.write(str(os.getpid()))
+
+    atexit.register(lambda: os.path.exists(LOCKFILE) and os.remove(LOCKFILE))
+
+
+async def main(*, force: bool = False) -> None:
+    """Start polling if the bot token is configured.
+
+    Parameters
+    ----------
+    force:
+        If ``True``, an existing lock file is ignored and replaced.
+    """
+
+    _acquire_lock(force)
+
     if not TOKEN:
         raise RuntimeError("BOT_TOKEN is not configured. Check your environment variables.")
     bot = Bot(token=TOKEN)

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -1,5 +1,6 @@
 """Entry point for running the Telegram bot."""
 
+import argparse
 import asyncio
 import logging
 import sys
@@ -10,12 +11,20 @@ from .config import validate_config
 logging.basicConfig(level=logging.INFO)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Run the bot and report missing configuration."""
+    parser = argparse.ArgumentParser(description="Run the Telegram bot")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Override existing lock file for emergency restarts",
+    )
+    args = parser.parse_args(argv)
+
     try:
         validate_config()
-        asyncio.run(run_bot())
-    except RuntimeError as exc:  # Missing configuration
+        asyncio.run(run_bot(force=args.force))
+    except RuntimeError as exc:  # Missing configuration or lock error
         logging.error("%s", exc)
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- prevent multiple polling processes by using `/tmp/alistabot.lock`
- allow emergency restarts with `--force` flag
- document lock behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a24f9eb0832bbf9551173b499905