### PR TITLE
Abort start when another instance is polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to l
 
 Only one polling process should run at a time. The bot creates a lock file at
 `/tmp/alistabot.lock` when it starts and stores the PID of the running process.
-If another process is already running, startup fails with an error. To override
-an apparently stale lock (for example after a crash), first check that the PID
-in the lock file does not correspond to a running process, then start the bot
-with the `--force` flag:
+If another process is already running, startup fails with an error. During
+startup the bot also performs a one-shot `getUpdates` request; if Telegram
+reports that another instance is already polling with the same token, the bot
+logs an error and exits. To override an apparently stale lock (for example
+after a crash), first check that the PID in the lock file does not correspond to
+a running process, then start the bot with the `--force` flag:
 
 ```
 python -m bot_alista.main --force

--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -90,9 +90,11 @@ async def main(*, force: bool = False) -> None:
     dp.include_router(request.router)
 
     try:
-        await dp.start_polling(bot)
+        await bot.get_updates(limit=1, timeout=0)
     except TelegramConflictError:
         logging.error(
             "Telegram reported a conflict: another bot instance may be running."
         )
         raise SystemExit(1)
+
+    await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- check for existing Telegram polling sessions before starting
- remove redundant try/except around `start_polling`
- document startup conflict detection in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5aad6bf94832bac2b2b25a261f774