### PR TITLE
Add PyYAML, tabulate, and currency_converter_free dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ aiogram>=3.0.0
 python-dotenv
 requests
 fpdf2
+PyYAML
+tabulate
+currency_converter_free


### PR DESCRIPTION
## Summary
- append PyYAML, tabulate, and currency_converter_free to requirements.txt

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyYAML)*
- `python - <<'PY'
modules = ['yaml', 'tabulate', 'currency_converter_free']
for mod in modules:
    try:
        __import__(mod)
        print(f'{mod} imported')
    except Exception as e:
        print(f'{mod} failed:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a704f4cd98832ba3156fd1237e162c