### PR TITLE
Add PyYAML dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install -r requirements.txt
 python bot_alista/main.py
 ```
 
-The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.
+The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically and [`PyYAML`](https://pypi.org/project/PyYAML/) for parsing YAML configuration files. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.
 
 ## Customs and duty calculations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ aiogram>=3.0.0
 python-dotenv
 requests
 fpdf2
-PyYAML
 tabulate
 currency_converter_free
+pyyaml


### PR DESCRIPTION
## Summary
- ensure PyYAML is listed as a dependency
- document use of PyYAML for YAML configuration

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8005947e4832ba411828f08eb826f