### PR TITLE
Add tests for CustomsCalculator ETC and CTP calculations

### DIFF
--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -33,3 +33,72 @@ class CustomsCalculator:
     def get_tariffs(cls) -> Dict[str, Any]:
         """Return cached tariff data."""
         return cls._load_config()
+
+    # ------------------------------------------------------------------
+    # Convenience calculation helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def calculate_ctp(
+        cls,
+        *,
+        price_eur: float,
+        engine_cc: int,
+        year: int,
+        car_type: str,
+        power_hp: float = 0,
+        weight_kg: float = 0,
+        eur_rate: float | None = None,
+        tariffs: Dict[str, Any] | None = None,
+    ) -> float:
+        """Return customs tax payments in euros for the given vehicle.
+
+        This is a thin wrapper around :func:`calculate_customs` that extracts
+        the ``total_eur`` field from the result.  ``tariffs`` may be supplied to
+        use custom tariff data; when omitted the bundled sample rates are used.
+        """
+
+        from .customs import calculate_customs  # Lazy import to avoid cycles
+
+        res = calculate_customs(
+            price_eur=price_eur,
+            engine_cc=engine_cc,
+            year=year,
+            car_type=car_type,
+            power_hp=power_hp,
+            weight_kg=weight_kg,
+            eur_rate=eur_rate,
+            tariffs=tariffs,
+        )
+        return res["total_eur"]
+
+    @classmethod
+    def calculate_etc(
+        cls,
+        *,
+        price_eur: float,
+        engine_cc: int,
+        year: int,
+        car_type: str,
+        power_hp: float = 0,
+        weight_kg: float = 0,
+        eur_rate: float | None = None,
+        tariffs: Dict[str, Any] | None = None,
+    ) -> float:
+        """Return the estimated total cost including customs payments.
+
+        ``ETC`` equals the vehicle price plus customs tax payments calculated by
+        :meth:`calculate_ctp`.
+        """
+
+        ctp = cls.calculate_ctp(
+            price_eur=price_eur,
+            engine_cc=engine_cc,
+            year=year,
+            car_type=car_type,
+            power_hp=power_hp,
+            weight_kg=weight_kg,
+            eur_rate=eur_rate,
+            tariffs=tariffs,
+        )
+        return price_eur + ctp


### PR DESCRIPTION
## Summary
- expose helper methods in `CustomsCalculator` to compute customs payments (`calculate_ctp`) and estimated total cost (`calculate_etc`)
- add unit tests using sample tariff data to verify both helpers produce expected totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8005bd310832b827fe16b7de5d69e