### PR TITLE
Include request handler router in bot startup

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 from aiogram import Bot, Dispatcher
 from config import TOKEN
-from handlers import menu, calculate, cancel, menu_navigation
+from handlers import menu, calculate, cancel, menu_navigation, request
 
 async def main():
     bot = Bot(token=TOKEN)
@@ -11,6 +11,7 @@ async def main():
     dp.include_router(calculate.router)
     dp.include_router(cancel.router)
     dp.include_router(menu_navigation.router)
+    dp.include_router(request.router)
 
     await dp.start_polling(bot)
 


### PR DESCRIPTION
## Summary
- import request handler and register its router before polling

## Testing
- `pytest -q` *(fails: JSONDecodeError in tests/test_customs_calculator.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a8080fe4b0832b9c3aefcc8b8e97d1