### PR TITLE
Add exit handler for ❌ Выход

### DIFF
--- a/bot_alista/handlers/menu_navigation.py
+++ b/bot_alista/handlers/menu_navigation.py
@@ -12,3 +12,12 @@ async def go_main_menu(message: types.Message, state: FSMContext):
 async def go_back(message: types.Message, state: FSMContext):
     # Просто возвращаем в главное меню
     await reset_to_menu(message, state)
+
+
+@router.message(F.text == "❌ Выход")
+async def exit_bot(message: types.Message, state: FSMContext):
+    """Очистка состояния и выход из бота."""
+    await state.clear()
+    await message.answer(
+        "👋 До новых встреч!", reply_markup=types.ReplyKeyboardRemove()
+    )


### PR DESCRIPTION
## Summary
- handle "❌ Выход" to clear FSM state and send a farewell message

## Testing
- `python -m pytest` *(fails: json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0))*

------
https://chatgpt.com/codex/tasks/task_e_68a80811fcec832bb445e9104f6fbe4a