### PR TITLE
feat: async rate fetching

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -349,7 +349,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         manual_rates = data.get("manual_rates", {})
         needed = {currency_code, "EUR"}
         try:
-            rates = get_cached_rates(decl_date, codes=("EUR", "USD", "JPY", "CNY"))
+            rates = await get_cached_rates(decl_date, codes=("EUR", "USD", "JPY", "CNY"))
             customs_value_rub = amount * rates[currency_code]
         except Exception:
             missing = [c for c in needed if c not in manual_rates]


### PR DESCRIPTION
## Summary
- switch rate fetching to async `asyncio.to_thread`
- update handler to await cached rates

## Testing
- `pytest -q` *(fails: JSONDecodeError: Expecting value: line 1 column 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a80820ab98832bb819651bee40c9a6