### PR TITLE
feat: make customs calculator async-friendly

### DIFF
--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -1,9 +1,60 @@
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any, Dict
+
 try:
     from tks_api_official import CustomsCalculator
 except Exception:  # pragma: no cover - fallback when package missing
     from .customs_calculator import CustomsCalculator
+
+
+def calculate_customs(
+    *,
+    price_eur: float,
+    engine_cc: int,
+    year: int,
+    car_type: str,
+    power_hp: float = 0,
+    weight_kg: float = 0,
+    eur_rate: float | None = None,
+    tariffs: Dict[str, Any] | None = None,
+) -> Dict[str, float]:
+    """Простейший расчёт таможенных платежей в евро.
+
+    Функция покрывает минимальный набор сценариев, необходимый для тестов.
+    Она учитывает пошлину, утилизационный сбор, НДС и сбор за оформление.
+    """
+
+    tariffs = tariffs or CustomsCalculator.get_tariffs()
+    age = datetime.now().year - year
+
+    if age < 3:
+        duty_cfg = tariffs["duty"]["under_3"]
+        duty = max(price_eur * duty_cfg["price_percent"], engine_cc * duty_cfg["per_cc"])
+        util = tariffs["utilization"]["age_under_3"]
+    else:
+        table_key = "3_5" if age <= 5 else "over_5"
+        table = tariffs["duty"][table_key]
+        rate = 0.0
+        for max_cc, r in table:
+            if engine_cc <= max_cc:
+                rate = r
+                break
+        duty = engine_cc * rate
+        util = tariffs["utilization"]["age_over_3"]
+
+    vat = (price_eur + duty + util) * 0.20
+    fee = tariffs["processing_fee"]
+    total = duty + util + vat + fee
+
+    return {
+        "duty_eur": duty,
+        "utilization_eur": util,
+        "vat_eur": vat,
+        "processing_fee_eur": fee,
+        "total_eur": total,
+    }
 
 
 def calculate_etc(*args, **kwargs):
@@ -16,4 +67,4 @@ def calculate_ctp(*args, **kwargs):
     return CustomsCalculator.calculate_ctp(*args, **kwargs)
 
 
-__all__ = ["calculate_etc", "calculate_ctp", "CustomsCalculator"]
+__all__ = ["calculate_customs", "calculate_etc", "calculate_ctp", "CustomsCalculator"]

--- a/tests/test_calculator_async.py
+++ b/tests/test_calculator_async.py
@@ -1,0 +1,52 @@
+import asyncio
+from datetime import date
+from pathlib import Path
+import sys
+
+# Ensure repo root on sys.path for module resolution
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import calculator
+
+
+def test_calculate_individual_async(monkeypatch):
+    async def fake_get_cbr_rate(for_date, code):
+        return 1.0
+
+    monkeypatch.setattr(calculator, "get_cbr_rate", fake_get_cbr_rate)
+    year = date.today().year - 1
+    result = asyncio.run(
+        calculator.calculate_individual(
+            customs_value=10_000,
+            currency="EUR",
+            engine_cc=2_000,
+            production_year=year,
+            fuel="бензин",
+        )
+    )
+    assert result["currency_rate"] == 1.0
+    assert result["eur_rate"] == 1.0
+    assert result["total_rub"] > 0
+
+
+def test_calculate_company_async(monkeypatch):
+    async def fake_get_cbr_rate(for_date, code):
+        return 1.0
+
+    monkeypatch.setattr(calculator, "get_cbr_rate", fake_get_cbr_rate)
+    year = date.today().year - 1
+    result = asyncio.run(
+        calculator.calculate_company(
+            customs_value=10_000,
+            currency="EUR",
+            engine_cc=2_000,
+            production_year=year,
+            fuel="бензин",
+            hp=150,
+        )
+    )
+    assert result["currency_rate"] == 1.0
+    assert result["eur_rate"] == 1.0
+    assert result["total_rub"] > 0


### PR DESCRIPTION
## Summary
- convert rate fetching to async and await Central Bank service
- expose async customs calculators for individuals and companies
- implement minimal customs calculation helper and add async tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a83a35bc24832b9395eeea15f01387