### PR TITLE
Use package-relative imports

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 from aiogram import Bot, Dispatcher
-from config import TOKEN
-from handlers import menu, calculate, cancel, menu_navigation, request
+from .config import TOKEN
+from .handlers import menu, calculate, cancel, menu_navigation, request
 
 async def main():
     bot = Bot(token=TOKEN)

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -9,10 +9,10 @@ from aiogram import F, Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 
-from states import CalculationStates
-from keyboards.navigation import back_menu
-from utils.reset import reset_to_menu
-from constants import (
+from ..states import CalculationStates
+from ..keyboards.navigation import back_menu
+from ..utils.reset import reset_to_menu
+from ..constants import (
     CURRENCY_CODES,
     PROMPT_PERSON,
     ERROR_PERSON,
@@ -36,12 +36,12 @@ from constants import (
     BTN_BACK,
     ERROR_RATE,
 )
-from bot_alista.services.rates import (
+from ..services.rates import (
     get_cached_rates,
     validate_or_prompt_rate,
 )
 from tariff_engine import calc_breakdown_rules
-from bot_alista.formatting import format_result_message
+from ..formatting import format_result_message
 
 
 router = Router()

--- a/bot_alista/handlers/cancel.py
+++ b/bot_alista/handlers/cancel.py
@@ -1,7 +1,7 @@
 from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from utils.reset import reset_to_menu
+from ..utils.reset import reset_to_menu
 
 router = Router()
 

--- a/bot_alista/handlers/menu.py
+++ b/bot_alista/handlers/menu.py
@@ -1,7 +1,7 @@
 from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from keyboards.main_menu import main_menu
+from ..keyboards.main_menu import main_menu
 
 router = Router()
 

--- a/bot_alista/handlers/menu_navigation.py
+++ b/bot_alista/handlers/menu_navigation.py
@@ -1,6 +1,6 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
-from utils.reset import reset_to_menu
+from ..utils.reset import reset_to_menu
 
 router = Router()
 

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -1,11 +1,11 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
-from states import RequestStates
-from keyboards.navigation import back_menu
-from services.email import send_email
-from services.pdf_report import generate_request_pdf
-from utils.reset import reset_to_menu
-from config import EMAIL_TO
+from ..states import RequestStates
+from ..keyboards.navigation import back_menu
+from ..services.email import send_email
+from ..services.pdf_report import generate_request_pdf
+from ..utils.reset import reset_to_menu
+from ..config import EMAIL_TO
 
 import asyncio
 import os

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -1,14 +1,11 @@
 """Entry point for running the Telegram bot."""
 
 import asyncio
-import sys
-import os
 import logging
 
 logging.basicConfig(level=logging.INFO)
 
-sys.path.append(os.path.dirname(__file__))
-from bot_alista.bot import main as run_bot
+from .bot import main as run_bot
 
 
 if __name__ == "__main__":

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict
+from datetime import datetime
 import yaml
 
 
@@ -38,6 +39,67 @@ class CustomsCalculator:
     # Convenience calculation helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _age_category(year: int) -> str:
+        age = datetime.now().year - year
+        if age < 3:
+            return "under_3"
+        if age <= 5:
+            return "3_5"
+        return "over_5"
+
+    @classmethod
+    def calculate_customs(
+        cls,
+        *,
+        price_eur: float,
+        engine_cc: int,
+        year: int,
+        car_type: str,
+        power_hp: float = 0,
+        weight_kg: float = 0,
+        eur_rate: float | None = None,
+        tariffs: Dict[str, Any] | None = None,
+    ) -> Dict[str, float]:
+        """Return detailed customs calculation using simple tariff rules."""
+        tariffs = tariffs or cls.get_tariffs()
+        eur_rate = eur_rate or 1.0
+        cat = cls._age_category(year)
+
+        # Duty
+        if cat == "under_3":
+            cfg = tariffs["duty"]["under_3"]
+            duty = max(price_eur * cfg["price_percent"], engine_cc * cfg["per_cc"])
+        else:
+            table = tariffs["duty"][cat]
+            rate = next(r for limit, r in table if engine_cc <= limit)
+            duty = engine_cc * rate
+
+        # Excise (only when engine volume over 3000 cc)
+        excise = 0.0
+        if engine_cc > 3000:
+            exc_cfg = tariffs.get("excise", {})
+            per_hp = exc_cfg.get("over_3000_hp_rub", 0.0) / eur_rate
+            excise = power_hp * per_hp
+
+        # Utilization fee
+        util_key = "age_under_3" if cat == "under_3" else "age_over_3"
+        util = tariffs.get("utilization", {}).get(util_key, 0.0)
+
+        # VAT is 20% of price + duty + excise + utilization
+        vat = 0.2 * (price_eur + duty + excise + util)
+        fee = tariffs.get("processing_fee", 0.0)
+
+        total = duty + excise + util + vat + fee
+        return {
+            "duty_eur": duty,
+            "excise_eur": excise,
+            "util_eur": util,
+            "vat_eur": vat,
+            "fee_eur": fee,
+            "total_eur": total,
+        }
+
     @classmethod
     def calculate_ctp(
         cls,
@@ -53,14 +115,12 @@ class CustomsCalculator:
     ) -> float:
         """Return customs tax payments in euros for the given vehicle.
 
-        This is a thin wrapper around :func:`calculate_customs` that extracts
+        This is a thin wrapper around :meth:`calculate_customs` that extracts
         the ``total_eur`` field from the result.  ``tariffs`` may be supplied to
         use custom tariff data; when omitted the bundled sample rates are used.
         """
 
-        from .customs import calculate_customs  # Lazy import to avoid cycles
-
-        res = calculate_customs(
+        res = cls.calculate_customs(
             price_eur=price_eur,
             engine_cc=engine_cc,
             year=year,

--- a/bot_alista/services/email.py
+++ b/bot_alista/services/email.py
@@ -6,7 +6,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from config import EMAIL_LOGIN, EMAIL_PASSWORD, SMTP_SERVER, SMTP_PORT
+from ..config import EMAIL_LOGIN, EMAIL_PASSWORD, SMTP_SERVER, SMTP_PORT
 
 
 def send_email(

--- a/bot_alista/utils/reset.py
+++ b/bot_alista/utils/reset.py
@@ -1,5 +1,5 @@
 from aiogram.fsm.context import FSMContext
-from keyboards.main_menu import main_menu
+from ..keyboards.main_menu import main_menu
 from aiogram import types
 
 async def reset_to_menu(message: types.Message, state: FSMContext):

--- a/tests/test_customs_calculator.py
+++ b/tests/test_customs_calculator.py
@@ -1,14 +1,8 @@
 import yaml
 from pathlib import Path
 from datetime import datetime
-import sys
 
 import pytest
-
-# Ensure repo root on sys.path for namespace package resolution
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 from bot_alista.services.customs_calculator import CustomsCalculator
 


### PR DESCRIPTION
## Summary
- switch internal modules to package-relative imports
- remove sys.path hacking from entry points and tests
- embed a simple customs calculation helper and rely on package execution

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a83a388fa8832bbdb99576fbe58efe