### PR TITLE
Use package execution for bot entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install dependencies and run the bot:
 
 ```
 pip install -r requirements.txt
-python bot_alista/main.py
+python -m bot_alista.main
 ```
 
 The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load variables from the `.env` file automatically and [`PyYAML`](https://pypi.org/project/PyYAML/) for parsing YAML configuration files. For container deployments, supply the same environment variables via your container runtime's secret or environment management instead of a `.env` file.

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -1,14 +1,11 @@
 """Entry point for running the Telegram bot."""
 
 import asyncio
-import sys
-import os
 import logging
 
-logging.basicConfig(level=logging.INFO)
+from .bot import main as run_bot
 
-sys.path.append(os.path.dirname(__file__))
-from bot_alista.bot import main as run_bot
+logging.basicConfig(level=logging.INFO)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Simplify bot entrypoint by using relative imports and package execution
- Update documentation to run the bot via `python -m bot_alista.main`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'calculate_customs')*

------
https://chatgpt.com/codex/tasks/task_e_68a83a3fe530832baa9dacc78bfd41e8