### PR TITLE
refactor: centralize clearance fee tiers

### DIFF
--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -16,4 +16,14 @@ def calculate_ctp(*args, **kwargs):
     return CustomsCalculator.calculate_ctp(*args, **kwargs)
 
 
-__all__ = ["calculate_etc", "calculate_ctp", "CustomsCalculator"]
+def calculate_customs(*args, **kwargs):
+    """Proxy to :class:`tks_api_official.CustomsCalculator.calculate_customs`."""
+    return CustomsCalculator.calculate_customs(*args, **kwargs)
+
+
+__all__ = [
+    "calculate_etc",
+    "calculate_ctp",
+    "calculate_customs",
+    "CustomsCalculator",
+]

--- a/bot_alista/tariff/clearance_fee.py
+++ b/bot_alista/tariff/clearance_fee.py
@@ -1,0 +1,24 @@
+"""Common customs clearance fee ladder."""
+from __future__ import annotations
+
+import math
+
+CLEARANCE_FEE_TABLE: list[tuple[float, float]] = [
+    (200_000, 1067),
+    (450_000, 2134),
+    (1_200_000, 4269),
+    (3_000_000, 11746),
+    (5_000_000, 16524),
+    (7_000_000, 20000),
+    (math.inf, 30000),
+]
+
+
+def calc_clearance_fee_rub(customs_value_rub: float) -> float:
+    """Return clearance fee (RUB) for a given customs value."""
+    if customs_value_rub <= 0:
+        raise ValueError("Таможенная стоимость должна быть положительной")
+    for limit, fee in CLEARANCE_FEE_TABLE:
+        if customs_value_rub <= limit:
+            return float(fee)
+    return float(CLEARANCE_FEE_TABLE[-1][1])

--- a/calculator.py
+++ b/calculator.py
@@ -13,6 +13,7 @@ from typing import Dict
 import math
 
 from bot_alista.services.rates import get_cbr_rate
+from bot_alista.tariff.clearance_fee import calc_clearance_fee_rub
 
 # ---------------------------------------------------------------------------
 # Вспомогательные структуры и таблицы тарифов
@@ -75,16 +76,6 @@ UTIL_COEFF_UL = {
     "5_7": 0.43,
     "over_7": 0.62,
 }
-
-CLEARANCE_FEE_TABLE = [
-    (200_000, 1067),
-    (450_000, 2134),
-    (1_200_000, 4269),
-    (3_000_000, 11746),
-    (5_000_000, 16524),
-    (7_000_000, 20000),
-    (math.inf, 30000),
-]
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +213,7 @@ def calculate_company(*, customs_value: float, currency: Currency, engine_cc: in
     util_rub = UTIL_BASE_UL * util_coeff
 
     # Сбор за оформление
-    fee_rub = _pick_rate(CLEARANCE_FEE_TABLE, value_rub)
+    fee_rub = calc_clearance_fee_rub(value_rub)
 
     total_rub = duty_rub + excise_rub + vat_rub + util_rub + fee_rub
 

--- a/tariff_engine.py
+++ b/tariff_engine.py
@@ -29,6 +29,7 @@ from bot_alista.rules.age import (
 )
 from bot_alista.rules.engine import calc_fl_stp, calc_ul
 from bot_alista.tariff.util_fee import calc_util_rub, UTIL_CONFIG
+from bot_alista.tariff.clearance_fee import calc_clearance_fee_rub
 
 ENGINE_CC_MIN = 2300
 ENGINE_CC_MAX = 3000
@@ -72,21 +73,6 @@ def _validate_positive_float(value: float, name: str) -> None:
         raise ValueError(f"{name} должно быть положительным числом")
 
 
-def calc_clearance_fee_rub(customs_value_rub: float) -> float:
-    """
-    Customs clearance fee ladder (RUB), tuned to hit known 2025 bands:
-      ~1.2M → 4,269 ; ~2.4M → 11,746 ; ~4.0M → 16,524
-    Extend as needed for higher tiers.
-    """
-    _validate_positive_float(customs_value_rub, "Таможенная стоимость")
-    v = float(customs_value_rub)
-    if v <= 200_000:    return 1_067.0
-    if v <= 450_000:    return 2_134.0
-    if v <= 1_200_000:  return 4_269.0
-    if v <= 3_000_000:  return 11_746.0
-    if v <= 5_000_000:  return 16_524.0
-    if v <= 7_000_000:  return 20_000.0
-    return 30_000.0
 
 
 # Public API ---------------------------------------------------------------

--- a/tests/test_clearance_fee.py
+++ b/tests/test_clearance_fee.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from datetime import date
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import calculator
+from tariff_engine import calc_clearance_fee_rub as engine_fee
+from bot_alista.tariff.clearance_fee import calc_clearance_fee_rub
+
+
+@pytest.mark.parametrize("value", [100_000, 200_000, 200_001, 450_000, 1_200_000, 3_500_000, 6_500_000, 8_000_000])
+def test_clearance_fee_consistency(monkeypatch, value):
+    # Consistency between shared module and tariff_engine
+    assert calc_clearance_fee_rub(value) == engine_fee(value)
+
+    # Stub out external rate fetching
+    monkeypatch.setattr(calculator, "_get_rate", lambda code: 1.0)
+
+    # Calculator should produce the same fee
+    result = calculator.calculate_company(
+        customs_value=value,
+        currency="RUB",
+        engine_cc=2500,
+        production_year=date.today().year,
+        fuel="бензин",
+        hp=150,
+    )
+    assert result["clearance_fee_rub"] == calc_clearance_fee_rub(value)


### PR DESCRIPTION
## Summary
- centralize customs clearance fee tiers in `tariff/clearance_fee.py`
- use shared clearance fee helper in `calculator.py` and `tariff_engine.py`
- add unit tests ensuring all calculators yield identical clearance fees
- expose `calculate_customs` in fallback services for full tariff calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83a447150832ba9e328c5a97ad230