### PR TITLE
refactor: introduce enums and validation

### DIFF
--- a/bot_alista/constants.py
+++ b/bot_alista/constants.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from .models.enums import PersonType, UsageType, FuelType, AgeCategory
+
 # Button labels
 BTN_CALC = "📊 Рассчитать"
 BTN_BACK = "⬅ Назад"
@@ -11,10 +13,7 @@ BTN_SEND = "📩 Отправить менеджеру"
 BTN_AGE_OVER3_YES = "Да"
 BTN_AGE_OVER3_NO = "Нет"
 
-# Type aliases
-PersonType = Literal["физическое лицо", "юридическое лицо"]
-UsageType = Literal["личное", "коммерческое"]
-FuelType = Literal["бензин", "дизель", "гибрид", "электро"]
+# Type aliases (re-exported for convenience)
 VehicleKind = Literal["легковой", "грузовой", "мототехника"]
 
 # Validation ranges

--- a/bot_alista/models/__init__.py
+++ b/bot_alista/models/__init__.py
@@ -1,0 +1,17 @@
+"""Model helpers and enumerations."""
+
+from .enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+    WrongParamException,
+)
+
+__all__ = [
+    "PersonType",
+    "UsageType",
+    "FuelType",
+    "AgeCategory",
+    "WrongParamException",
+]

--- a/bot_alista/models/enums.py
+++ b/bot_alista/models/enums.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Shared enumeration types used across the project."""
+
+from enum import Enum
+from typing import Type, TypeVar
+
+
+class WrongParamException(ValueError):
+    """Raised when a parameter cannot be parsed into a required enum."""
+
+    def __init__(self, param: str, value: object) -> None:
+        message = f"Invalid value for {param}: {value!r}"
+        super().__init__(message)
+        self.param = param
+        self.value = value
+
+
+T = TypeVar("T", bound=Enum)
+
+
+def _cast_enum(enum: Type[T], value: str, param: str) -> T:
+    """Cast *value* to *enum* or raise :class:`WrongParamException`."""
+    try:
+        return enum(value)
+    except ValueError as exc:  # pragma: no cover - rewrap for clarity
+        raise WrongParamException(param, value) from exc
+
+
+class PersonType(str, Enum):
+    INDIVIDUAL = "individual"
+    COMPANY = "company"
+
+    @classmethod
+    def from_str(cls, value: str) -> "PersonType":
+        return _cast_enum(cls, value.lower(), "person_type")
+
+
+class UsageType(str, Enum):
+    PERSONAL = "personal"
+    COMMERCIAL = "commercial"
+
+    @classmethod
+    def from_str(cls, value: str) -> "UsageType":
+        return _cast_enum(cls, value.lower(), "usage_type")
+
+
+class FuelType(str, Enum):
+    ICE = "ice"
+    HYBRID = "hybrid"
+    EV = "ev"
+
+    @classmethod
+    def from_str(cls, value: str) -> "FuelType":
+        return _cast_enum(cls, value.lower(), "fuel_type")
+
+
+class AgeCategory(str, Enum):
+    """Vehicle age bucket used by utilization fee logic."""
+
+    UNDER_OR_EQUAL_3 = "<=3y"
+    OVER_3 = ">3y"
+
+    @classmethod
+    def from_str(cls, value: str) -> "AgeCategory":
+        return _cast_enum(cls, value, "age_category")
+
+    @classmethod
+    def from_age_years(cls, age_years: float) -> "AgeCategory":
+        if age_years < 0:
+            raise WrongParamException("age_years", age_years)
+        return cls.UNDER_OR_EQUAL_3 if age_years <= 3 else cls.OVER_3

--- a/bot_alista/tariff/util_fee.py
+++ b/bot_alista/tariff/util_fee.py
@@ -30,13 +30,18 @@ from datetime import date
 from typing import Dict, Literal
 import copy
 
-PersonType = Literal["individual", "company"]
-UsageType = Literal["personal", "commercial"]
-FuelType = Literal["ice", "hybrid", "ev"]
+from ..models.enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+    WrongParamException,
+)
+
 VehicleKind = Literal["passenger", "commercial"]
 
 
-def get_age_bucket(age_years: float) -> Literal["<=3y", ">3y"]:
+def get_age_bucket(age_years: float) -> AgeCategory:
     """Return age bucket for a vehicle.
 
     Parameters
@@ -46,9 +51,9 @@ def get_age_bucket(age_years: float) -> Literal["<=3y", ">3y"]:
 
     Returns
     -------
-    Literal["<=3y", ">3y"]
-        ``"<=3y"`` when ``age_years`` is less than or equal to three,
-        otherwise ``">3y"``.
+    AgeCategory
+        ``AgeCategory.UNDER_OR_EQUAL_3`` when ``age_years`` is less than or
+        equal to three, otherwise ``AgeCategory.OVER_3``.
 
     Raises
     ------
@@ -57,14 +62,14 @@ def get_age_bucket(age_years: float) -> Literal["<=3y", ">3y"]:
     """
 
     if age_years < 0:
-        raise ValueError("age_years must be non-negative")
-    return "<=3y" if age_years <= 3 else ">3y"
+        raise WrongParamException("age_years", age_years)
+    return AgeCategory.UNDER_OR_EQUAL_3 if age_years <= 3 else AgeCategory.OVER_3
 
 
 def pick_personal_coeff(
     engine_cc: int,
     fuel: FuelType,
-    age_bucket: str,
+    age_bucket: AgeCategory,
     config: Dict,
 ) -> float:
     """Pick coefficient for personal usage.
@@ -93,20 +98,18 @@ def pick_personal_coeff(
         missing.
     """
 
-    if fuel not in {"ice", "hybrid", "ev"}:
-        raise ValueError("Unknown fuel type")
     if engine_cc < 0:
         raise ValueError("engine_cc must be non-negative")
-    if fuel == "ice" and engine_cc == 0:
+    if fuel is FuelType.ICE and engine_cc == 0:
         raise ValueError("engine_cc must be positive for ICE vehicles")
 
     personal = config.get("coefficients_personal")
-    if not personal or age_bucket not in personal:
+    if not personal or age_bucket.value not in personal:
         raise ValueError("Invalid configuration for personal coefficients")
 
-    age_cfg = personal[age_bucket]
-    if fuel in {"ev", "hybrid"}:
-        coeff = age_cfg.get(fuel)
+    age_cfg = personal[age_bucket.value]
+    if fuel in {FuelType.EV, FuelType.HYBRID}:
+        coeff = age_cfg.get(fuel.value)
         if coeff is None:
             raise ValueError("Coefficient for fuel not found in config")
         return float(coeff)
@@ -150,12 +153,12 @@ def calc_util_ed_rub(
         On any invalid parameter or missing configuration.
     """
 
-    if person_type not in {"individual", "company"}:
-        raise ValueError("Unknown person_type")
-    if usage not in {"personal", "commercial"}:
-        raise ValueError("Unknown usage type")
-    if fuel not in {"ice", "hybrid", "ev"}:
-        raise ValueError("Unknown fuel type")
+    if not isinstance(person_type, PersonType):
+        raise WrongParamException("person_type", person_type)
+    if not isinstance(usage, UsageType):
+        raise WrongParamException("usage", usage)
+    if not isinstance(fuel, FuelType):
+        raise WrongParamException("fuel", fuel)
     if vehicle_kind not in {"passenger", "commercial"}:
         raise ValueError("Unknown vehicle kind")
 
@@ -166,14 +169,14 @@ def calc_util_ed_rub(
 
     age_bucket = get_age_bucket(age_years)
 
-    if person_type == "individual" and usage == "personal":
+    if person_type is PersonType.INDIVIDUAL and usage is UsageType.PERSONAL:
         coeff = pick_personal_coeff(engine_cc, fuel, age_bucket, config)
     else:
         # Company or commercial usage
         commercial_cfg = config.get("coefficients_commercial")
         if not commercial_cfg:
             raise ValueError("Commercial coefficients missing in config")
-        if fuel in {"ev", "hybrid"}:
+        if fuel in {FuelType.EV, FuelType.HYBRID}:
             key = "ev_or_hybrid"
         else:
             key = "default"

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,26 @@
+import pytest
+
+from bot_alista.models.enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+    WrongParamException,
+)
+
+
+def test_enum_parsing_success():
+    assert PersonType.from_str("individual") is PersonType.INDIVIDUAL
+    assert UsageType.from_str("commercial") is UsageType.COMMERCIAL
+    assert FuelType.from_str("ev") is FuelType.EV
+    assert AgeCategory.from_str("<=3y") is AgeCategory.UNDER_OR_EQUAL_3
+    assert AgeCategory.from_age_years(4.1) is AgeCategory.OVER_3
+
+
+def test_enum_parsing_errors():
+    with pytest.raises(WrongParamException):
+        PersonType.from_str("unknown")
+    with pytest.raises(WrongParamException):
+        FuelType.from_str("steam")
+    with pytest.raises(WrongParamException):
+        AgeCategory.from_age_years(-1)


### PR DESCRIPTION
## Summary
- add shared enums for person, usage, fuel and age categories with custom WrongParamException
- refactor handlers and tariff calculations to rely on enums instead of raw strings
- cover enum parsing and error cases with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a842a17f64832b92517de5b9645ec1