### PR TITLE
refactor: introduce enums and validation

### DIFF
--- a/bot_alista/constants.py
+++ b/bot_alista/constants.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from .models.enums import PersonType, UsageType, FuelType, AgeCategory
+
 # Button labels
 BTN_CALC = "📊 Рассчитать"
 BTN_BACK = "⬅ Назад"
@@ -11,10 +13,7 @@ BTN_SEND = "📩 Отправить менеджеру"
 BTN_AGE_OVER3_YES = "Да"
 BTN_AGE_OVER3_NO = "Нет"
 
-# Type aliases
-PersonType = Literal["физическое лицо", "юридическое лицо"]
-UsageType = Literal["личное", "коммерческое"]
-FuelType = Literal["бензин", "дизель", "гибрид", "электро"]
+# Type aliases (re-exported for convenience)
 VehicleKind = Literal["легковой", "грузовой", "мототехника"]
 
 # Validation ranges

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -42,6 +42,30 @@ from ..services.rates import (
 )
 from tariff_engine import calc_breakdown_rules
 from ..formatting import format_result_message
+from ..models.enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+)
+
+
+PERSON_MAP = {
+    "Физическое лицо": PersonType.INDIVIDUAL,
+    "Юридическое лицо": PersonType.COMPANY,
+}
+
+USAGE_MAP = {
+    "Личное": UsageType.PERSONAL,
+    "Коммерческое": UsageType.COMMERCIAL,
+}
+
+FUEL_MAP = {
+    "Бензин": FuelType.GASOLINE,
+    "Дизель": FuelType.DIESEL,
+    "Гибрид": FuelType.HYBRID,
+    "Электро": FuelType.EV,
+}
 
 
 router = Router()
@@ -131,10 +155,11 @@ async def start_calculation(message: types.Message, state: FSMContext) -> None:
 async def get_person_type(message: types.Message, state: FSMContext) -> None:
     if await _check_nav(message, state, None, None, None):
         return
-    if message.text not in {"Физическое лицо", "Юридическое лицо"}:
+    person = PERSON_MAP.get(message.text)
+    if not person:
         await message.answer(ERROR_PERSON)
         return
-    await state.update_data(person_type=message.text)
+    await state.update_data(person_type=person)
     await state.set_state(CalculationStates.usage_type)
     await message.answer(PROMPT_USAGE, reply_markup=_usage_type_kb())
 
@@ -145,10 +170,11 @@ async def get_usage_type(message: types.Message, state: FSMContext) -> None:
         message, state, CalculationStates.person_type, PROMPT_PERSON, _person_type_kb()
     ):
         return
-    if message.text not in {"Личное", "Коммерческое"}:
+    usage = USAGE_MAP.get(message.text)
+    if not usage:
         await message.answer(ERROR_USAGE)
         return
-    await state.update_data(usage_type=message.text)
+    await state.update_data(usage_type=usage)
     await state.set_state(CalculationStates.calc_type)
     await message.answer(PROMPT_TYPE, reply_markup=_car_type_kb())
 
@@ -163,10 +189,11 @@ async def get_car_type(message: types.Message, state: FSMContext) -> None:
         _usage_type_kb(),
     ):
         return
-    if message.text not in {"Бензин", "Дизель", "Гибрид", "Электро"}:
+    fuel = FUEL_MAP.get(message.text)
+    if not fuel:
         await message.answer(ERROR_TYPE)
         return
-    await state.update_data(car_type=message.text)
+    await state.update_data(car_type=fuel)
     await state.set_state(CalculationStates.currency_code)
     await message.answer(PROMPT_CURRENCY, reply_markup=_currency_kb())
 
@@ -198,7 +225,7 @@ async def get_amount(message: types.Message, state: FSMContext) -> None:
         return
     await state.update_data(amount=amount)
     data = await state.get_data()
-    if data.get("car_type") != "Электро":
+    if data.get("car_type") is not FuelType.EV:
         await state.set_state(CalculationStates.calc_engine)
         await message.answer(PROMPT_ENGINE, reply_markup=back_menu())
     else:
@@ -230,8 +257,12 @@ async def get_engine(message: types.Message, state: FSMContext) -> None:
 @router.message(CalculationStates.calc_power)
 async def get_power(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
-    prev_state = CalculationStates.calc_engine if data.get("car_type") != "Электро" else CalculationStates.customs_value_amount
-    prev_prompt = PROMPT_ENGINE if data.get("car_type") != "Электро" else PROMPT_AMOUNT
+    prev_state = (
+        CalculationStates.calc_engine
+        if data.get("car_type") is not FuelType.EV
+        else CalculationStates.customs_value_amount
+    )
+    prev_prompt = PROMPT_ENGINE if data.get("car_type") is not FuelType.EV else PROMPT_AMOUNT
     prev_kb = back_menu()
     if await _check_nav(message, state, prev_state, prev_prompt, prev_kb):
         return
@@ -272,9 +303,11 @@ async def get_year(message: types.Message, state: FSMContext) -> None:
     CalculationStates.age_over_3, F.text.in_({BTN_AGE_OVER3_YES, BTN_AGE_OVER3_NO})
 )
 async def on_age_over_3_choice(message: types.Message, state: FSMContext) -> None:
-    over3 = message.text == BTN_AGE_OVER3_YES
-    age_years = 4.0 if over3 else 2.0
-    await state.update_data(age_years=age_years, age_over_3=over3)
+    age_cat = (
+        AgeCategory.OVER_3 if message.text == BTN_AGE_OVER3_YES else AgeCategory.UNDER_OR_EQUAL_3
+    )
+    age_years = 4.0 if age_cat is AgeCategory.OVER_3 else 2.0
+    await state.update_data(age_years=age_years, age_category=age_cat)
 
     # Hide the age keyboard immediately
     await message.answer("Принято ✅", reply_markup=types.ReplyKeyboardRemove())
@@ -333,17 +366,14 @@ async def get_manual_rate(message: types.Message, state: FSMContext) -> None:
 async def _run_calculation(state: FSMContext, message: types.Message) -> None:
     data = await state.get_data()
     try:
-        car_type: str = data["car_type"]
+        fuel_type: FuelType = data["car_type"]
         currency_code: str = data["currency_code"]
         amount: float = data["amount"]
         engine_cc: int = data.get("engine", 0)
         engine_hp: int = int(data.get("power_hp", 0))
         year: int = data["year"]
-        person_ru: str = data.get("person_type", "Физическое лицо")
-        usage_ru: str = data.get("usage_type", "Личное")
-
-        person_type = "individual" if person_ru == "Физическое лицо" else "company"
-        usage_type = "personal" if usage_ru == "Личное" else "commercial"
+        person_type: PersonType = data.get("person_type", PersonType.INDIVIDUAL)
+        usage_type: UsageType = data.get("usage_type", UsageType.PERSONAL)
 
         decl_date = data.get("decl_date") or date.today()
         manual_rates = data.get("manual_rates", {})
@@ -366,8 +396,8 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         eur_rate = rates["EUR"]
         customs_value_eur = round(customs_value_rub / eur_rate, 2)
 
-        fuel_type = car_type
-        age_over_3 = bool(data.get("age_over_3", False))
+        age_category: AgeCategory = data.get("age_category", AgeCategory.UNDER_OR_EQUAL_3)
+        age_over_3 = age_category is AgeCategory.OVER_3
 
         core = calc_breakdown_rules(
             person_type=person_type,
@@ -394,12 +424,12 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
         meta = {
             "person_usage": (
                 "Тип лица: Физическое, личное использование"
-                if person_type == "individual" and usage_type == "personal"
+                if person_type is PersonType.INDIVIDUAL and usage_type is UsageType.PERSONAL
                 else "Тип лица: Юридическое / коммерческое использование"
             ),
             "age_info": "Выбор для пошлины (ФЛ): "
             + ("старше 3 лет" if age_over_3 else "не старше 3 лет")
-            if person_type == "individual" and usage_type == "personal"
+            if person_type is PersonType.INDIVIDUAL and usage_type is UsageType.PERSONAL
             else "",
             "util_age_info": "",
             "duty_rate_info": rate_line,

--- a/bot_alista/models/__init__.py
+++ b/bot_alista/models/__init__.py
@@ -1,0 +1,17 @@
+"""Model helpers and enumerations."""
+
+from .enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+    WrongParamException,
+)
+
+__all__ = [
+    "PersonType",
+    "UsageType",
+    "FuelType",
+    "AgeCategory",
+    "WrongParamException",
+]

--- a/bot_alista/models/enums.py
+++ b/bot_alista/models/enums.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Shared enumeration types used across the project."""
+
+from enum import Enum
+from typing import Type, TypeVar
+
+
+class WrongParamException(ValueError):
+    """Raised when a parameter cannot be parsed into a required enum."""
+
+    def __init__(self, param: str, value: object) -> None:
+        message = f"Invalid value for {param}: {value!r}"
+        super().__init__(message)
+        self.param = param
+        self.value = value
+
+
+T = TypeVar("T", bound=Enum)
+
+
+def _cast_enum(enum: Type[T], value: str, param: str) -> T:
+    """Cast *value* to *enum* or raise :class:`WrongParamException`."""
+    try:
+        return enum(value)
+    except ValueError as exc:  # pragma: no cover - rewrap for clarity
+        raise WrongParamException(param, value) from exc
+
+
+class PersonType(str, Enum):
+    INDIVIDUAL = "individual"
+    COMPANY = "company"
+
+    @classmethod
+    def from_str(cls, value: str) -> "PersonType":
+        return _cast_enum(cls, value.lower(), "person_type")
+
+
+class UsageType(str, Enum):
+    PERSONAL = "personal"
+    COMMERCIAL = "commercial"
+
+    @classmethod
+    def from_str(cls, value: str) -> "UsageType":
+        return _cast_enum(cls, value.lower(), "usage_type")
+
+
+class FuelType(str, Enum):
+    GASOLINE = "gasoline"
+    DIESEL = "diesel"
+    HYBRID = "hybrid"
+    EV = "ev"
+
+    @classmethod
+    def from_str(cls, value: str) -> "FuelType":
+        return _cast_enum(cls, value.lower(), "fuel_type")
+
+
+class AgeCategory(str, Enum):
+    """Vehicle age bucket used by utilization fee logic."""
+
+    UNDER_OR_EQUAL_3 = "<=3y"
+    OVER_3 = ">3y"
+
+    @classmethod
+    def from_str(cls, value: str) -> "AgeCategory":
+        return _cast_enum(cls, value, "age_category")
+
+    @classmethod
+    def from_age_years(cls, age_years: float) -> "AgeCategory":
+        if age_years < 0:
+            raise WrongParamException("age_years", age_years)
+        return cls.UNDER_OR_EQUAL_3 if age_years <= 3 else cls.OVER_3

--- a/tariff_engine.py
+++ b/tariff_engine.py
@@ -18,7 +18,6 @@ from bot_alista.tariff.personal_rates import (
 from bot_alista.rules.loader import (
     load_rules,
     get_available_age_labels,
-    normalize_fuel_label,
     RuleRow,
 )
 from bot_alista.rules.age import (
@@ -28,7 +27,15 @@ from bot_alista.rules.age import (
     candidate_fl_labels,
 )
 from bot_alista.rules.engine import calc_fl_stp, calc_ul
+from bot_alista.models.enums import PersonType, UsageType, FuelType
 from bot_alista.tariff.util_fee import calc_util_rub, UTIL_CONFIG
+
+FUEL_LABELS: dict[FuelType, str] = {
+    FuelType.GASOLINE: "Бензин",
+    FuelType.DIESEL: "Дизель",
+    FuelType.HYBRID: "Гибрид",
+    FuelType.EV: "Электро",
+}
 
 ENGINE_CC_MIN = 2300
 ENGINE_CC_MAX = 3000
@@ -212,7 +219,7 @@ def calc_import_breakdown(
     engine_hp: int,
     is_disabled_vehicle: bool,
     is_export: bool,
-    person_type: str = "individual",
+    person_type: PersonType = PersonType.INDIVIDUAL,
     country_origin: str | None = None,
 ) -> dict[str, Any]:
     """Полный расчет таможенных платежей при импорте.
@@ -296,8 +303,8 @@ def calc_import_breakdown(
 
 def calc_breakdown_with_mode(
     *,
-    person_type: str,
-    usage_type: str,
+    person_type: PersonType,
+    usage_type: UsageType,
     customs_value_eur: float,
     eur_rub_rate: float,
     engine_cc: int,
@@ -325,7 +332,7 @@ def calc_breakdown_with_mode(
         core["breakdown"]["clearance_fee_rub"] = 0.0
         return core
 
-    if person_type == "individual" and usage_type == "personal":
+    if person_type == PersonType.INDIVIDUAL and usage_type == UsageType.PERSONAL:
         customs_value_rub = eur_to_rub(customs_value_eur, eur_rub_rate)
 
         core = {
@@ -390,28 +397,28 @@ def calc_breakdown_with_mode(
 
 def calc_breakdown_rules(
     *,
-    person_type: str,          # "individual" | "company"
-    usage_type: str,           # "personal"  | "commercial"
+    person_type: PersonType,
+    usage_type: UsageType,
     customs_value_eur: float,
     eur_rub_rate: float,
     engine_cc: int | None,
     engine_hp: int | None,
     production_year: int,
-    age_choice_over3: bool,    # FL: user's answer to "older than 3?"
-    fuel_type: str,
+    age_choice_over3: bool,
+    fuel_type: FuelType,
     decl_date: date | None,
     segment: str = "Легковой",
     category: str = "M1",
 ) -> dict:
 
     decl_date = decl_date or date.today()
-    fuel_norm = normalize_fuel_label(fuel_type)
+    fuel_norm = FUEL_LABELS[fuel_type]
     rules, labels, buckets = _get_rule_env()
 
     customs_value_rub = round(customs_value_eur * eur_rub_rate, 2)
     actual_age = compute_actual_age_years(production_year, decl_date)
 
-    if person_type == "individual" and usage_type == "personal":
+    if person_type == PersonType.INDIVIDUAL and usage_type == UsageType.PERSONAL:
         # Resolve FL age label with graceful fallback
         fl_age_candidates = candidate_fl_labels(age_choice_over3, actual_age, buckets)
         last_exc: Exception | None = None
@@ -439,10 +446,10 @@ def calc_breakdown_rules(
         # UTIL uses factual age (not the user's button)
         util_age_years = 4.0 if actual_age > 3.0 else 2.0
         util_rub = calc_util_rub(
-            person_type="individual",
-            usage="personal",
+            person_type=PersonType.INDIVIDUAL,
+            usage=UsageType.PERSONAL,
             engine_cc=int(engine_cc or 0),
-            fuel=("ev" if fuel_norm == "Электро" else "ice"),
+            fuel=fuel_type,
             vehicle_kind="passenger",
             age_years=util_age_years,
             date_decl=decl_date,
@@ -508,10 +515,10 @@ def calc_breakdown_rules(
     total_no_util = round(core["duty_rub"] + core["excise_rub"] + core["vat_rub"] + fee_rub, 2)
 
     util_rub = calc_util_rub(
-        person_type="company",
-        usage="commercial",
+        person_type=PersonType.COMPANY,
+        usage=UsageType.COMMERCIAL,
         engine_cc=int(engine_cc or 0),
-        fuel=("ev" if fuel_norm == "Электро" else "ice"),
+        fuel=fuel_type,
         vehicle_kind="passenger",
         age_years=actual_age,
         date_decl=decl_date,

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,28 @@
+import pytest
+
+from bot_alista.models.enums import (
+    PersonType,
+    UsageType,
+    FuelType,
+    AgeCategory,
+    WrongParamException,
+)
+
+
+def test_enum_parsing_success():
+    assert PersonType.from_str("individual") is PersonType.INDIVIDUAL
+    assert UsageType.from_str("commercial") is UsageType.COMMERCIAL
+    assert FuelType.from_str("ev") is FuelType.EV
+    assert FuelType.from_str("gasoline") is FuelType.GASOLINE
+    assert FuelType.from_str("diesel") is FuelType.DIESEL
+    assert AgeCategory.from_str("<=3y") is AgeCategory.UNDER_OR_EQUAL_3
+    assert AgeCategory.from_age_years(4.1) is AgeCategory.OVER_3
+
+
+def test_enum_parsing_errors():
+    with pytest.raises(WrongParamException):
+        PersonType.from_str("unknown")
+    with pytest.raises(WrongParamException):
+        FuelType.from_str("steam")
+    with pytest.raises(WrongParamException):
+        AgeCategory.from_age_years(-1)


### PR DESCRIPTION
## Summary
- add shared enums for person, usage, fuel and age categories with custom WrongParamException
- refactor handlers and tariff calculations to rely on enums instead of raw strings
- cover enum parsing and error cases with new tests
- distinguish gasoline and diesel fuel types and map enums to rule labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a842a17f64832b92517de5b9645ec1