### PR TITLE
Add RUB currency conversion and update calculator

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -9,10 +9,10 @@ from aiogram import F, Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 
-from states import CalculationStates
-from keyboards.navigation import back_menu
-from utils.reset import reset_to_menu
-from constants import (
+from ..states import CalculationStates
+from ..keyboards.navigation import back_menu
+from ..utils.reset import reset_to_menu
+from ..constants import (
     CURRENCY_CODES,
     PROMPT_PERSON,
     ERROR_PERSON,
@@ -36,13 +36,13 @@ from constants import (
     BTN_BACK,
     ERROR_RATE,
 )
-from services.rates import (
+from ..services.rates import (
     get_cached_rates,
     validate_or_prompt_rate,
 )
-from formatting import format_result_message
-from services.customs_calculator import CustomsCalculator
-from rules.age import compute_actual_age_years
+from ..formatting import format_result_message
+from ..services.customs_calculator import CustomsCalculator
+from ..rules.age import compute_actual_age_years
 
 router = Router()
 

--- a/bot_alista/services/currency.py
+++ b/bot_alista/services/currency.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-"""Utility helpers for currency conversion to EUR."""
+"""Utility helpers for currency conversion.
+
+The project historically converted all prices directly to euro.  The new
+implementation converts values to roubles first (using rates from the
+Central Bank of Russia) and derives euro amounts from those figures.  A
+legacy :func:`to_eur` helper is retained for backwards compatibility.
+"""
 
 try:
     from currency_converter_free import CurrencyConverter
@@ -8,32 +14,51 @@ except Exception:  # pragma: no cover - fallback name
     from currency_converter_free import CurrencyConverter
 
 _converter: CurrencyConverter | None = None
-_FALLBACK_RATES = {"USD": 0.9, "KRW": 0.0007, "RUB": 0.01}
+_FALLBACK_RUB_RATES = {"USD": 90.0, "KRW": 0.07, "EUR": 100.0}
 
 
 def _get_converter() -> CurrencyConverter:
     global _converter
     if _converter is None:
-        _converter = CurrencyConverter()
+        _converter = CurrencyConverter(source="CBR")
     return _converter
 
 
+def to_rub(amount: float, currency: str) -> float:
+    """Convert ``amount`` from ``currency`` to Russian roubles.
+
+    The converter uses official CBR rates when available and falls back to a
+    small built‑in table if the data source is inaccessible.
+    """
+
+    code = currency.upper()
+    if code == "RUB":
+        return float(amount)
+    try:
+        converter = _get_converter()
+        return float(converter.convert(amount, code, "RUB"))
+    except Exception:
+        rate = _FALLBACK_RUB_RATES.get(code)
+        if rate is None:
+            raise ValueError(f"Unsupported currency: {currency}")
+        return float(amount) * rate
+
+
 def to_eur(amount: float, currency: str) -> float:
-    """Convert ``amount`` from ``currency`` to EUR.
+    """Convert ``amount`` from ``currency`` to euro.
+
+    This helper is kept for existing callers.  Internally it converts the
+    value to roubles first and then divides by the current rouble/euro rate.
 
     :param amount: value in the original currency
     :param currency: ISO currency code, e.g. ``"USD"``
     :return: amount converted to euros
     :raises ValueError: if currency is unsupported
     """
+
     code = currency.upper()
     if code == "EUR":
         return float(amount)
-    try:
-        converter = _get_converter()
-        return float(converter.convert(amount, code, "EUR"))
-    except Exception:
-        rate = _FALLBACK_RATES.get(code)
-        if rate is None:
-            raise ValueError(f"Unsupported currency: {currency}")
-        return float(amount) * rate
+    amount_rub = to_rub(amount, code)
+    eur_rate = to_rub(1.0, "EUR")
+    return amount_rub / eur_rate

--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 try:  # pragma: no cover - optional external package
     from tks_api_official import CustomsCalculator as _ExternalCalculator
 except Exception:  # pragma: no cover - fallback to bundled implementation
-    from customs_calculator import CustomsCalculator as _ExternalCalculator
+    from .customs_calculator import CustomsCalculator as _ExternalCalculator
 
 _calc: _ExternalCalculator | None = None
 

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 import yaml
 
-from services.currency import to_eur
+from .currency import to_rub
 
 
 class CustomsCalculator:
@@ -62,7 +62,8 @@ class CustomsCalculator:
         if engine_capacity < 800 or engine_capacity > 8000:
             raise ValueError("engine_capacity out of range")
 
-        price_eur = to_eur(price, currency)
+        price_rub = to_rub(price, currency)
+        price_eur = price_rub / self.eur_rate
 
         self._vehicle = {
             "age": age,

--- a/bot_alista/utils/reset.py
+++ b/bot_alista/utils/reset.py
@@ -1,5 +1,5 @@
 from aiogram.fsm.context import FSMContext
-from keyboards.main_menu import main_menu
+from ..keyboards.main_menu import main_menu
 from aiogram import types
 
 async def reset_to_menu(message: types.Message, state: FSMContext):


### PR DESCRIPTION
## Summary
- add `to_rub` helper using CBR rates with graceful fallbacks
- refactor customs calculator to convert via roubles and reuse new helper
- fix package-relative imports so modules load in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aabb65ae54832babff37ac3178c718