### PR TITLE
Replace external customs import with bundled implementation

### DIFF
--- a/bot_alista/services/customs.py
+++ b/bot_alista/services/customs.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-try:  # pragma: no cover - optional external package
-    from tks_api_official import CustomsCalculator as _ExternalCalculator
-except Exception:  # pragma: no cover - fallback to bundled implementation
-    from .customs_calculator import CustomsCalculator as _ExternalCalculator
+from .customs_calculator import CustomsCalculator as _ExternalCalculator
 
 _calc: _ExternalCalculator | None = None
 

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -225,9 +225,10 @@ class CustomsCalculator:
 
     def _duty(self, age: VehicleAge, engine_type: EngineType, engine_cc: int) -> float:
         cfg = self.tariffs["age_groups"][age.value][engine_type.value]
-        rate = cfg.get("rate_per_cc", 0)
-        min_duty = cfg.get("min_duty", 0)
-        return max(rate * engine_cc, min_duty)
+        rate_rub = cfg.get("rate_per_cc", 0)
+        min_duty_rub = cfg.get("min_duty", 0)
+        duty_rub = max(rate_rub * engine_cc, min_duty_rub)
+        return float(duty_rub) / self.eur_rate
 
     def _excise(self, engine_type: EngineType, power: int) -> float:
         rate_rub = self.tariffs["excise_rates"].get(engine_type.value, 0)

--- a/bot_alista/services/customs_rates.py
+++ b/bot_alista/services/customs_rates.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from customs_calculator import CustomsCalculator
+from .customs_calculator import CustomsCalculator
 
 # Simple in-memory cache per day
 _cached_tariffs: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- use internal customs calculator instead of optional external package
- adjust duty calculation to treat tariff values as RUB
- update services to import calculator via relative path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac2687bd0832b958b9f536132ee17