### PR TITLE
Use currency_converter when available

### DIFF
--- a/bot_alista/services/currency.py
+++ b/bot_alista/services/currency.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
-"""Utility helpers for currency conversion to EUR."""
+"""Utility helpers for currency conversion to EUR.
+
+This module prefers the :mod:`currency_converter` library but falls back to
+``currency_converter_free`` if the primary dependency is unavailable.
+"""
+
+import logging
 
 try:
-    from currency_converter_free import CurrencyConverter
-except Exception:  # pragma: no cover - fallback name
+    from currency_converter import CurrencyConverter
+except Exception:  # pragma: no cover - fallback to free library
+    logging.getLogger(__name__).warning(
+        "currency_converter not available; using currency_converter_free instead"
+    )
     from currency_converter_free import CurrencyConverter
 
 _converter: CurrencyConverter | None = None

--- a/bot_alista/services/currency.py
+++ b/bot_alista/services/currency.py
@@ -8,10 +8,12 @@ This module prefers the :mod:`currency_converter` library but falls back to
 
 import logging
 
+logger = logging.getLogger(__name__)
+
 try:
     from currency_converter import CurrencyConverter
 except Exception:  # pragma: no cover - fallback to free library
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "currency_converter not available; using currency_converter_free instead"
     )
     from currency_converter_free import CurrencyConverter

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -227,7 +227,8 @@ class CustomsCalculator:
         cfg = self.tariffs["age_groups"][age.value][engine_type.value]
         rate = cfg.get("rate_per_cc", 0)
         min_duty = cfg.get("min_duty", 0)
-        return max(rate * engine_cc, min_duty)
+        # Tariff values are expressed in RUB; convert to EUR for calculations
+        return float(max(rate * engine_cc, min_duty)) / self.eur_rate
 
     def _excise(self, engine_type: EngineType, power: int) -> float:
         rate_rub = self.tariffs["excise_rates"].get(engine_type.value, 0)

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -225,10 +225,11 @@ class CustomsCalculator:
 
     def _duty(self, age: VehicleAge, engine_type: EngineType, engine_cc: int) -> float:
         cfg = self.tariffs["age_groups"][age.value][engine_type.value]
-        rate = cfg.get("rate_per_cc", 0)
-        min_duty = cfg.get("min_duty", 0)
+        rate_rub = cfg.get("rate_per_cc", 0)
+        min_duty_rub = cfg.get("min_duty", 0)
+        duty_rub = max(rate_rub * engine_cc, min_duty_rub)
         # Tariff values are expressed in RUB; convert to EUR for calculations
-        return float(max(rate * engine_cc, min_duty)) / self.eur_rate
+        return float(duty_rub) / self.eur_rate
 
     def _excise(self, engine_type: EngineType, power: int) -> float:
         rate_rub = self.tariffs["excise_rates"].get(engine_type.value, 0)


### PR DESCRIPTION
## Summary
- Prefer `currency_converter` with a logged warning fallback to `currency_converter_free`
- Document currency converter preference in the currency helper
- Fix customs duty calculation by converting RUB tariffs to EUR using the exchange rate

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aac26b0934832ba9d43bc438e6e364