### PR TITLE
Refactor customs calculator to operate in RUB

### DIFF
--- a/bot_alista/services/__init__.py
+++ b/bot_alista/services/__init__.py
@@ -1,3 +1,21 @@
-from .customs import calculate_etc, calculate_ctp, CustomsCalculator
+"""Convenience exports for service layer."""
 
-__all__ = ["calculate_etc", "calculate_ctp", "CustomsCalculator"]
+from .customs_calculator import CustomsCalculator
+
+
+def calculate_ctp(**kwargs):
+    """Return CTP calculation for one-off use."""
+    calc = CustomsCalculator()
+    calc.set_vehicle_details(**kwargs)
+    return calc.calculate_ctp()
+
+
+def calculate_etc(**kwargs):
+    """Return ETC calculation for one-off use."""
+    calc = CustomsCalculator()
+    calc.set_vehicle_details(**kwargs)
+    return calc.calculate_etc()
+
+
+__all__ = ["calculate_ctp", "calculate_etc", "CustomsCalculator"]
+

--- a/bot_alista/services/currency.py
+++ b/bot_alista/services/currency.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Utility helpers for currency conversion to EUR."""
+"""Utility helpers for currency conversion."""
 
 try:
     from currency_converter_free import CurrencyConverter
@@ -9,6 +9,7 @@ except Exception:  # pragma: no cover - fallback name
 
 _converter: CurrencyConverter | None = None
 _FALLBACK_RATES = {"USD": 0.9, "KRW": 0.0007, "RUB": 0.01}
+_EUR_TO_RUB = 1 / _FALLBACK_RATES["RUB"]
 
 
 def _get_converter() -> CurrencyConverter:
@@ -48,3 +49,33 @@ def to_eur(amount: float, currency: str, eur_rate: float | None = None) -> float
         if rate is None:
             raise ValueError(f"Unsupported currency: {currency}")
         return float(amount) * rate
+
+
+def to_rub(amount: float, currency: str) -> float:
+    """Convert ``amount`` from ``currency`` to RUB.
+
+    The function first tries :mod:`currency_converter_free` and falls back to
+    a small static rate table when conversion data is unavailable.
+
+    :param amount: value in the original currency
+    :param currency: ISO currency code, e.g. ``"USD"``
+    :return: amount converted to rubles
+    :raises ValueError: if currency is unsupported
+    """
+
+    code = currency.upper()
+    if code == "RUB":
+        return float(amount)
+    try:
+        converter = _get_converter()
+        return float(converter.convert(amount, code, "RUB"))
+    except Exception:
+        if code == "EUR":
+            return float(amount) * _EUR_TO_RUB
+        rate_eur = _FALLBACK_RATES.get(code)
+        if rate_eur is None:
+            raise ValueError(f"Unsupported currency: {currency}")
+        return float(amount) * rate_eur * _EUR_TO_RUB
+
+
+__all__ = ["to_eur", "to_rub"]


### PR DESCRIPTION
## Summary
- add flexible `to_rub` helper for currency conversion
- rewrite customs calculator for RUB-based duty, VAT, recycling and util fee computation
- align calculation handler and tests with new RUB workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aab89c5b08832b98265762d6a64963