### PR TITLE
refactor navigation and add faq

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 from aiogram import Bot, Dispatcher
 from config import TOKEN
-from handlers import menu, calculate, cancel, menu_navigation, request
+from handlers import menu, calculate, cancel, menu_navigation, request, faq
 
 async def main():
     bot = Bot(token=TOKEN)
@@ -12,6 +12,7 @@ async def main():
     dp.include_router(cancel.router)
     dp.include_router(menu_navigation.router)
     dp.include_router(request.router)
+    dp.include_router(faq.router)
 
     await dp.start_polling(bot)
 

--- a/bot_alista/constants.py
+++ b/bot_alista/constants.py
@@ -3,6 +3,8 @@ from typing import Literal
 # Button labels
 BTN_CALC = "📊 Рассчитать"
 BTN_BACK = "⬅ Назад"
+BTN_MAIN_MENU = "🏠 Главное меню"
+BTN_EXIT = "❌ Выход"
 BTN_FAQ = "ℹ️ FAQ"
 BTN_LEAD = "📞 Заявка"
 BTN_LAST = "🧾 Последний расчёт"

--- a/bot_alista/handlers/faq.py
+++ b/bot_alista/handlers/faq.py
@@ -1,0 +1,19 @@
+from aiogram import Router, types, F
+from aiogram.fsm.context import FSMContext
+
+from bot_alista.constants import BTN_FAQ, BTN_CALC, BTN_LEAD
+from bot_alista.keyboards.navigation import back_menu
+
+router = Router()
+
+FAQ_TEXT = (
+    "ℹ️ <b>FAQ</b>\n"
+    "- Как рассчитать пошлину? Используйте пункт \"{calc}\" в главном меню.\n"
+    "- Как оставить заявку? Нажмите \"{lead}\" и заполните форму.\n"
+    "- Нужна помощь? Свяжитесь с менеджером.".format(calc=BTN_CALC, lead=BTN_LEAD)
+)
+
+
+@router.message(F.text == BTN_FAQ)
+async def show_faq(message: types.Message, state: FSMContext) -> None:
+    await message.answer(FAQ_TEXT, reply_markup=back_menu())

--- a/bot_alista/handlers/menu_navigation.py
+++ b/bot_alista/handlers/menu_navigation.py
@@ -1,20 +1,22 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
-from utils.reset import reset_to_menu
+
+from bot_alista.constants import BTN_MAIN_MENU, BTN_BACK, BTN_EXIT
+from bot_alista.utils.reset import reset_to_menu
 
 router = Router()
 
-@router.message(F.text == "🏠 Главное меню")
+@router.message(F.text == BTN_MAIN_MENU)
 async def go_main_menu(message: types.Message, state: FSMContext):
     await reset_to_menu(message, state)
 
-@router.message(F.text == "⬅ Назад")
+@router.message(F.text == BTN_BACK)
 async def go_back(message: types.Message, state: FSMContext):
     # Просто возвращаем в главное меню
     await reset_to_menu(message, state)
 
 
-@router.message(F.text == "❌ Выход")
+@router.message(F.text == BTN_EXIT)
 async def exit_bot(message: types.Message, state: FSMContext):
     """Очистка состояния и выход из бота."""
     await state.clear()

--- a/bot_alista/keyboards/main_menu.py
+++ b/bot_alista/keyboards/main_menu.py
@@ -1,10 +1,19 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
+from bot_alista.constants import (
+    BTN_CALC,
+    BTN_LEAD,
+    BTN_EXIT,
+    BTN_FAQ,
+)
+
+
 def main_menu():
     kb = [
-        [KeyboardButton(text="📊 Рассчитать стоимость таможенной очистки")],
-        [KeyboardButton(text="📝 Оставить заявку")],
-        [KeyboardButton(text="❌ Выход")]
+        [KeyboardButton(text=BTN_CALC)],
+        [KeyboardButton(text=BTN_LEAD)],
+        [KeyboardButton(text=BTN_FAQ)],
+        [KeyboardButton(text=BTN_EXIT)],
     ]
     return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)
 

--- a/bot_alista/keyboards/navigation.py
+++ b/bot_alista/keyboards/navigation.py
@@ -1,8 +1,18 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
+from bot_alista.constants import (
+    BTN_BACK,
+    BTN_MAIN_MENU,
+    BTN_FAQ,
+    BTN_AGE_OVER3_YES,
+    BTN_AGE_OVER3_NO,
+)
+
+
 def back_menu():
     kb = [
-        [KeyboardButton(text="⬅ Назад"), KeyboardButton(text="🏠 Главное меню")]
+        [KeyboardButton(text=BTN_BACK), KeyboardButton(text=BTN_MAIN_MENU)],
+        [KeyboardButton(text=BTN_FAQ)],
     ]
     return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)
 
@@ -10,7 +20,7 @@ def back_menu():
 def yes_no_menu() -> ReplyKeyboardMarkup:
     """Keyboard with Yes/No options and main menu button."""
     kb = [
-        [KeyboardButton(text="Да"), KeyboardButton(text="Нет")],
-        [KeyboardButton(text="🏠 Главное меню")]
+        [KeyboardButton(text=BTN_AGE_OVER3_YES), KeyboardButton(text=BTN_AGE_OVER3_NO)],
+        [KeyboardButton(text=BTN_MAIN_MENU)]
     ]
     return ReplyKeyboardMarkup(keyboard=kb, resize_keyboard=True)

--- a/bot_alista/utils/navigation.py
+++ b/bot_alista/utils/navigation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from aiogram import types
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State
+
+from bot_alista.constants import BTN_BACK, BTN_MAIN_MENU
+from bot_alista.utils.reset import reset_to_menu
+
+
+@dataclass
+class NavStep:
+    state: State
+    prompt: str
+    kb: types.ReplyKeyboardMarkup
+
+
+class NavigationManager:
+    """Simple navigation stack with back/main menu handling."""
+
+    def __init__(self, total_steps: int) -> None:
+        self.total_steps = total_steps
+        self.stack: List[NavStep] = []
+
+    async def push(
+        self,
+        message: types.Message,
+        fsm: FSMContext,
+        step: NavStep,
+    ) -> None:
+        self.stack.append(step)
+        await fsm.set_state(step.state)
+        await message.answer(
+            f"Шаг {len(self.stack)}/{self.total_steps}: {step.prompt}",
+            reply_markup=step.kb,
+        )
+
+    async def handle_nav(self, message: types.Message, fsm: FSMContext) -> bool:
+        if message.text == BTN_MAIN_MENU:
+            await reset_to_menu(message, fsm)
+            self.stack.clear()
+            return True
+        if message.text == BTN_BACK and len(self.stack) > 1:
+            self.stack.pop()
+            prev = self.stack[-1]
+            await fsm.set_state(prev.state)
+            await message.answer(
+                f"Шаг {len(self.stack)}/{self.total_steps}: {prev.prompt}",
+                reply_markup=prev.kb,
+            )
+            return True
+        return False

--- a/bot_alista/utils/reset.py
+++ b/bot_alista/utils/reset.py
@@ -1,8 +1,9 @@
 from aiogram.fsm.context import FSMContext
 from bot_alista.keyboards.main_menu import main_menu
+from bot_alista.constants import BTN_MAIN_MENU
 from aiogram import types
 
 async def reset_to_menu(message: types.Message, state: FSMContext):
     """Сброс FSM и возврат в главное меню"""
     await state.clear()
-    await message.answer("🏠 Главное меню:", reply_markup=main_menu())
+    await message.answer(f"{BTN_MAIN_MENU}:", reply_markup=main_menu())


### PR DESCRIPTION
## Summary
- centralize button labels and expose FAQ entry
- add navigation manager with step progress and shared back/main menu handling
- streamline calculate and request workflows with unified navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad20102d4832b9fcc38318e227783