### PR TITLE
Fix customs fee logic and clean PDF rendering

### DIFF
--- a/bot_alista/services/pdf_report.py
+++ b/bot_alista/services/pdf_report.py
@@ -28,7 +28,6 @@ class PDFReport(FPDF):
     def footer(self):
         self.set_y(-15)
         self.set_font("DejaVu", "", 8)
-        self.cell(0, 10, f"Стр. {self.page_no()}", align="C")
         self.cell(0, 10, _sanitize(f"Стр. {self.page_no()}", strip_currency=False), align="C")
 
 
@@ -61,16 +60,10 @@ def _sanitize(text: str, *, strip_currency: bool = True) -> str:
 def generate_request_pdf(data: dict, filename: str):
     """Генерация PDF заявки на растаможку."""
     pdf = PDFReport()
-    pdf.title = "Заявка на растаможку"
     pdf.title = _sanitize("Заявка на растаможку", strip_currency=False)
     pdf.add_page()
 
     pdf.set_font("DejaVu", "", 12)
-    pdf.cell(0, 8, f"ФИО: {data.get('name', '')}", ln=True)
-    pdf.cell(0, 8, f"Авто: {data.get('car', '')}", ln=True)
-    pdf.cell(0, 8, f"Контакты: {data.get('contact', '')}", ln=True)
-    pdf.cell(0, 8, f"Стоимость: {data.get('price', '')} €", ln=True)
-    pdf.multi_cell(0, 8, f"Комментарий: {data.get('comment', '')}")
     pdf.cell(0, 8, _sanitize(f"ФИО: {data.get('name', '')}"), ln=True)
     pdf.cell(0, 8, _sanitize(f"Авто: {data.get('car', '')}"), ln=True)
     pdf.cell(0, 8, _sanitize(f"Контакты: {data.get('contact', '')}"), ln=True)
@@ -83,16 +76,10 @@ def generate_request_pdf(data: dict, filename: str):
 def generate_calculation_pdf(result: dict, user_info: dict, filename: str):
     """Генерация PDF отчёта по расчёту растаможки."""
     pdf = PDFReport()
-    pdf.title = "Отчёт по расчёту растаможки"
     pdf.title = _sanitize("Отчёт по расчёту растаможки", strip_currency=False)
     pdf.add_page()
 
     pdf.set_font("DejaVu", "B", 12)
-    pdf.cell(0, 8, f"Тип авто: {user_info.get('car_type', '')}", ln=True)
-    pdf.cell(0, 8, f"Год выпуска: {user_info.get('year', '')}", ln=True)
-    pdf.cell(0, 8, f"Мощность: {user_info.get('power_hp', '')} л.с.", ln=True)
-    pdf.cell(0, 8, f"Объём двигателя: {user_info.get('engine', '')} см³", ln=True)
-    pdf.cell(0, 8, f"Масса: {user_info.get('weight', '')} кг", ln=True)
     pdf.cell(0, 8, _sanitize(f"Тип авто: {user_info.get('car_type', '')}"), ln=True)
     pdf.cell(0, 8, _sanitize(f"Год выпуска: {user_info.get('year', '')}"), ln=True)
     pdf.cell(0, 8, _sanitize(f"Мощность: {user_info.get('power_hp', '')} л.с."), ln=True)
@@ -100,19 +87,15 @@ def generate_calculation_pdf(result: dict, user_info: dict, filename: str):
     pdf.cell(0, 8, _sanitize(f"Масса: {user_info.get('weight', '')} кг"), ln=True)
     # some calculators may provide price under different keys
     price_eur = result.get("price_eur") or result.get("vehicle_price_eur", "")
-    pdf.cell(0, 8, f"Цена: {price_eur} €", ln=True)
     pdf.cell(0, 8, _sanitize(f"Цена: {price_eur} €"), ln=True)
     pdf.ln(5)
 
     # Таблица расчёта
     pdf.set_font("DejaVu", "B", 12)
-    pdf.cell(0, 10, "Результаты расчёта", ln=True)
     pdf.cell(0, 10, _sanitize("Результаты расчёта", strip_currency=False), ln=True)
     pdf.set_font("DejaVu", "", 11)
 
     def add_row(name, value):
-        pdf.cell(90, 8, name, border=1)
-        pdf.cell(0, 8, str(value), border=1, ln=True)
         pdf.cell(90, 8, _sanitize(name, strip_currency=False), border=1)
         pdf.cell(0, 8, _sanitize(str(value)), border=1, ln=True)
 

--- a/tests/test_customs_calculator.py
+++ b/tests/test_customs_calculator.py
@@ -98,7 +98,16 @@ def test_calculate_ctp_returns_expected_total(calc: CustomsCalculator, vehicle_u
     excise_rub = tariffs["excise_rates"]["gasoline"] * vehicle_usd["power"]
     util_rub = tariffs["base_util_fee"] * tariffs["ctp_util_coeff_base"]
     recycling_rub = RECYCLING_FEE_BASE_RATE * tariffs["recycling_factors"]["adjustments"]["5-7"]["gasoline"]
-    fee_rub = tariffs["base_clearance_fee"]
+    price_limit_map = [
+        (200_000, 1_067),
+        (450_000, 2_134),
+        (1_200_000, 4_269),
+        (3_000_000, 11_746),
+        (5_000_000, 16_524),
+        (7_000_000, 20_000),
+        (float("inf"), 30_000),
+    ]
+    fee_rub = next(tax for limit, tax in price_limit_map if price_rub <= limit)
     vat_rub = tariffs["vat_rate"] * (price_rub + duty_rub + excise_rub)
     expected_total = duty_rub + excise_rub + util_rub + recycling_rub + vat_rub + fee_rub
 


### PR DESCRIPTION
## Summary
- Apply tiered customs clearance fee for corporate imports and support hybrid util-fee mapping
- Use tariff-based VAT and clearance fee schedule with ETC util coefficient
- Clean PDF report rendering and missing imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad65340d4832b8af30d1e73632f4e