### PR TITLE
Add navigation buttons to calculation result

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -480,7 +480,11 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             core=core,
             util_fee_rub=core["breakdown"].get("util_rub", 0.0),
         )
-        await message.answer(msg, disable_web_page_preview=True)
+        await message.answer(
+            msg,
+            disable_web_page_preview=True,
+            reply_markup=back_menu(),
+        )
         await state.clear()
     except Exception as exc:  # pragma: no cover - defensive
         logging.exception("Calculation failed: %s", exc)

--- a/tests/test_calculate_handler.py
+++ b/tests/test_calculate_handler.py
@@ -11,6 +11,8 @@ if str(ROOT) not in sys.path:
 calculate = pytest.importorskip("bot_alista.handlers.calculate")
 _run_calculation = calculate._run_calculation
 
+from bot_alista.constants import BTN_BACK, BTN_MAIN_MENU
+
 
 class FakeState:
     def __init__(self, data):
@@ -35,7 +37,7 @@ class FakeMessage:
         self.answers = []
 
     async def answer(self, text, **kwargs):
-        self.answers.append(text)
+        self.answers.append((text, kwargs))
 
 
 def test_run_calculation(monkeypatch):
@@ -62,5 +64,10 @@ def test_run_calculation(monkeypatch):
     )
     msg = FakeMessage()
     asyncio.run(_run_calculation(state, msg))
-    assert "ok" in msg.answers[0]
+    text, kwargs = msg.answers[0]
+    assert text == "ok"
+    markup = kwargs.get("reply_markup")
+    assert markup is not None
+    labels = [btn.text for row in markup.keyboard for btn in row]
+    assert BTN_BACK in labels and BTN_MAIN_MENU in labels
     assert state.cleared


### PR DESCRIPTION
## Summary
- ensure calculation results include back menu for navigation
- test that calculation replies expose navigation markup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae7912958832b8e2412554af279c5