### PR TITLE
Add automatic tariff selection and vehicle type support

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -431,8 +431,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             owner_type=person_type,
             currency=currency_code,
         )
-
-        breakdown = calc.calculate_ctp()
+        breakdown = calc.calculate_auto()
         customs_value_rub = breakdown["price_rub"]
         core = {
             "breakdown": {

--- a/bot_alista/services/__init__.py
+++ b/bot_alista/services/__init__.py
@@ -17,5 +17,17 @@ def calculate_etc(**kwargs):
     return calc.calculate_etc()
 
 
-__all__ = ["calculate_ctp", "calculate_etc", "CustomsCalculator"]
+def calculate_auto(**kwargs):
+    """Return automatic ETC/CTP calculation for one-off use."""
+    calc = CustomsCalculator()
+    calc.set_vehicle_details(**kwargs)
+    return calc.calculate_auto()
+
+
+__all__ = [
+    "calculate_ctp",
+    "calculate_etc",
+    "calculate_auto",
+    "CustomsCalculator",
+]
 

--- a/external/tks_api_official/config.yaml
+++ b/external/tks_api_official/config.yaml
@@ -2,87 +2,91 @@ base_clearance_fee: 3100
 base_util_fee: 20000
 etc_util_coeff_base: 1.0
 ctp_util_coeff_base: 1.2
-excise_rates:
-  gasoline: 58
-  diesel: 58
-  electric: 0
-  hybrid: 58
-recycling_factors:
-  default:
-    gasoline: 1.0
-    diesel: 1.1
-    electric: 0.3
-    hybrid: 1.0
-  adjustments:
-    "5-7":
-      gasoline: 0.26
-      diesel: 0.26
-      electric: 0.26
-      hybrid: 0.26
-age_groups:
-  new:
-    gasoline:
-      rate_per_cc: 2.5
-      min_duty: 0
-    diesel:
-      rate_per_cc: 2.7
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 1.8
-      min_duty: 2000
-  "1-3":
-    gasoline:
-      rate_per_cc: 3.0
-      min_duty: 0
-    diesel:
-      rate_per_cc: 3.2
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.0
-      min_duty: 2000
-  "3-5":
-    gasoline:
-      rate_per_cc: 4.0
-      min_duty: 0
-    diesel:
-      rate_per_cc: 4.2
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.5
-      min_duty: 2500
-  "5-7":
-    gasoline:
-      rate_per_cc: 4.8
-      min_duty: 0
-    diesel:
-      rate_per_cc: 5.0
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.0
-      min_duty: 2500
-  over_7:
-    gasoline:
-      rate_per_cc: 5.5
-      min_duty: 0
-    diesel:
-      rate_per_cc: 5.8
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 3.0
-      min_duty: 3000
+vehicle_types:
+  passenger: &passenger
+    excise_rates:
+      gasoline: 58
+      diesel: 58
+      electric: 0
+      hybrid: 58
+    recycling_factors:
+      default:
+        gasoline: 1.0
+        diesel: 1.1
+        electric: 0.3
+        hybrid: 1.0
+      adjustments:
+        "5-7":
+          gasoline: 0.26
+          diesel: 0.26
+          electric: 0.26
+          hybrid: 0.26
+    age_groups:
+      new:
+        gasoline:
+          rate_per_cc: 2.5
+          min_duty: 0
+        diesel:
+          rate_per_cc: 2.7
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 1.8
+          min_duty: 2000
+      "1-3":
+        gasoline:
+          rate_per_cc: 3.0
+          min_duty: 0
+        diesel:
+          rate_per_cc: 3.2
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.0
+          min_duty: 2000
+      "3-5":
+        gasoline:
+          rate_per_cc: 4.0
+          min_duty: 0
+        diesel:
+          rate_per_cc: 4.2
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.5
+          min_duty: 2500
+      "5-7":
+        gasoline:
+          rate_per_cc: 4.8
+          min_duty: 0
+        diesel:
+          rate_per_cc: 5.0
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.0
+          min_duty: 2500
+      over_7:
+        gasoline:
+          rate_per_cc: 5.5
+          min_duty: 0
+        diesel:
+          rate_per_cc: 5.8
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 3.0
+          min_duty: 3000
+  truck:
+    <<: *passenger
 vat_rate: 0.2


### PR DESCRIPTION
## Summary
- add vehicle type enum and per-type tariff loading
- convert ETC duty rates from EUR to RUB
- implement automatic selection between ETC and CTP and expose helper

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae5127de4832b9a8daf962cdcc898