### PR TITLE
Handle personal-use customs duty

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -431,8 +431,7 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             owner_type=person_type,
             currency=currency_code,
         )
-
-        breakdown = calc.calculate_ctp()
+        breakdown = calc.calculate_auto()
         customs_value_rub = breakdown["price_rub"]
         core = {
             "breakdown": {

--- a/bot_alista/services/__init__.py
+++ b/bot_alista/services/__init__.py
@@ -17,5 +17,17 @@ def calculate_etc(**kwargs):
     return calc.calculate_etc()
 
 
-__all__ = ["calculate_ctp", "calculate_etc", "CustomsCalculator"]
+def calculate_auto(**kwargs):
+    """Return automatic ETC/CTP calculation for one-off use."""
+    calc = CustomsCalculator()
+    calc.set_vehicle_details(**kwargs)
+    return calc.calculate_auto()
+
+
+__all__ = [
+    "calculate_ctp",
+    "calculate_etc",
+    "calculate_auto",
+    "CustomsCalculator",
+]
 

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -12,6 +12,16 @@ from tabulate import tabulate
 
 from .currency import to_rub
 from .tariffs import get_tariffs
+try:  # pragma: no cover - fallback for direct test import
+    from ..tariff.personal_rates import (
+        CUSTOMS_CLEARANCE_FEE_RUB,
+        calc_individual_personal_duty_eur,
+    )
+except Exception:  # pragma: no cover - fallback
+    from tariff.personal_rates import (
+        CUSTOMS_CLEARANCE_FEE_RUB,
+        calc_individual_personal_duty_eur,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +72,11 @@ class VehicleOwnerType(Enum):
     COMPANY = "company"
 
 
+class VehicleType(Enum):
+    PASSENGER = "passenger"
+    TRUCK = "truck"
+
+
 @dataclass
 class _Vehicle:
     age: VehicleAge
@@ -71,6 +86,7 @@ class _Vehicle:
     price_rub: float
     owner_type: VehicleOwnerType
     currency: str
+    vehicle_type: VehicleType
 
 
 class CustomsCalculator:
@@ -101,6 +117,7 @@ class CustomsCalculator:
         price: float,
         owner_type: str | VehicleOwnerType,
         currency: str = "USD",
+        vehicle_type: str | VehicleType = "passenger",
     ) -> None:
         try:
             age_enum = age if isinstance(age, VehicleAge) else VehicleAge(age)
@@ -109,6 +126,11 @@ class CustomsCalculator:
             )
             owner_enum = (
                 owner_type if isinstance(owner_type, VehicleOwnerType) else VehicleOwnerType(owner_type)
+            )
+            vehicle_type_enum = (
+                vehicle_type
+                if isinstance(vehicle_type, VehicleType)
+                else VehicleType(vehicle_type)
             )
         except ValueError as exc:
             raise WrongParamException(str(exc))
@@ -129,12 +151,19 @@ class CustomsCalculator:
             price_rub=float(price_rub),
             owner_type=owner_enum,
             currency=currency.upper(),
+            vehicle_type=vehicle_type_enum,
         )
 
     def _require_vehicle(self) -> _Vehicle:
         if not self.vehicle:
             raise WrongParamException("Vehicle details not set")
         return self.vehicle
+
+    def _vehicle_tariffs(self, v: _Vehicle) -> Dict[str, Any]:
+        vt = self.tariffs.get("vehicle_types")
+        if vt:
+            return vt[v.vehicle_type.value]
+        return self.tariffs
 
     # ------------------------------------------------------------------
     # Fee helpers
@@ -150,7 +179,8 @@ class CustomsCalculator:
 
     def calculate_recycling_fee(self) -> float:
         v = self._require_vehicle()
-        factors = self.tariffs["recycling_factors"]
+        vt = self._vehicle_tariffs(v)
+        factors = vt["recycling_factors"]
         default = factors.get("default", {})
         adjustments = factors.get("adjustments", {}).get(v.age.value, {})
         engine_factor = adjustments.get(
@@ -162,7 +192,8 @@ class CustomsCalculator:
 
     def calculate_excise(self) -> float:
         v = self._require_vehicle()
-        rate = self.tariffs["excise_rates"].get(v.engine_type.value, 0)
+        vt = self._vehicle_tariffs(v)
+        rate = vt["excise_rates"].get(v.engine_type.value, 0)
         excise = rate * v.power
         logger.info("Excise: %s RUB", excise)
         return float(excise)
@@ -170,6 +201,41 @@ class CustomsCalculator:
     # ------------------------------------------------------------------
     # Calculation modes
     # ------------------------------------------------------------------
+    def _age_years(self, age: VehicleAge) -> float:
+        mapping = {
+            VehicleAge.NEW: 0.0,
+            VehicleAge.ONE_TO_THREE: 2.0,
+            VehicleAge.THREE_TO_FIVE: 4.0,
+            VehicleAge.FIVE_TO_SEVEN: 6.0,
+            VehicleAge.OVER_SEVEN: 8.0,
+        }
+        return mapping[age]
+
+    def calculate_personal(self) -> Dict[str, float]:
+        v = self._require_vehicle()
+        age_years = self._age_years(v.age)
+        duty_eur = calc_individual_personal_duty_eur(v.engine_capacity, age_years)
+        duty_rub = to_rub(duty_eur, "EUR")
+
+        clearance_fee = CUSTOMS_CLEARANCE_FEE_RUB
+        util_fee = self.tariffs["base_util_fee"]
+        recycling_fee = self.calculate_recycling_fee()
+
+        total_pay = duty_rub + clearance_fee + util_fee + recycling_fee
+        res = {
+            "mode": "PERSONAL",
+            "price_rub": v.price_rub,
+            "duty_rub": duty_rub,
+            "excise_rub": 0.0,
+            "vat_rub": 0.0,
+            "fee_rub": clearance_fee,
+            "util_rub": util_fee,
+            "recycling_rub": recycling_fee,
+            "total_rub": total_pay,
+        }
+        self._last_result = res
+        return res
+
     def calculate_ctp(self) -> Dict[str, float]:
         v = self._require_vehicle()
         price_rub = v.price_rub
@@ -190,6 +256,7 @@ class CustomsCalculator:
 
         total_pay = duty_rub + excise + vat + clearance_fee + util_fee + recycling_fee
         res = {
+            "mode": "CTP",
             "price_rub": price_rub,
             "duty_rub": duty_rub,
             "excise_rub": excise,
@@ -204,10 +271,12 @@ class CustomsCalculator:
 
     def calculate_etc(self) -> Dict[str, float]:
         v = self._require_vehicle()
-        cfg = self.tariffs["age_groups"][v.age.value][v.engine_type.value]
-        rate_per_cc = cfg["rate_per_cc"]
+        vt = self._vehicle_tariffs(v)
+        cfg = vt["age_groups"][v.age.value][v.engine_type.value]
+        rate_per_cc = to_rub(cfg["rate_per_cc"], "EUR")
         min_duty = cfg.get("min_duty", 0)
-        duty_rub = max(rate_per_cc * v.engine_capacity, min_duty)
+        min_duty_rub = to_rub(min_duty, "EUR") if min_duty else 0
+        duty_rub = max(rate_per_cc * v.engine_capacity, min_duty_rub)
 
         clearance_fee = self.calculate_clearance_tax()
         util_fee = self.tariffs["base_util_fee"] * self.tariffs.get(
@@ -217,7 +286,11 @@ class CustomsCalculator:
 
         total_pay = duty_rub + clearance_fee + util_fee + recycling_fee
         res = {
+            "mode": "ETC",
+            "price_rub": v.price_rub,
             "duty_rub": duty_rub,
+            "excise_rub": 0.0,
+            "vat_rub": 0.0,
             "fee_rub": clearance_fee,
             "util_rub": util_fee,
             "recycling_rub": recycling_fee,
@@ -227,6 +300,16 @@ class CustomsCalculator:
         }
         self._last_result = res
         return res
+
+    def calculate_auto(self) -> Dict[str, float]:
+        v = self._require_vehicle()
+        if v.owner_type is VehicleOwnerType.INDIVIDUAL:
+            return self.calculate_personal()
+        ctp = self.calculate_ctp()
+        etc = self.calculate_etc()
+        chosen = ctp if ctp["total_rub"] >= etc["total_rub"] else etc
+        self._last_result = chosen
+        return chosen
 
     # ------------------------------------------------------------------
     # Debug helper
@@ -254,6 +337,7 @@ __all__ = [
     "EngineType",
     "VehicleAge",
     "VehicleOwnerType",
+    "VehicleType",
     "WrongParamException",
 ]
 

--- a/external/tks_api_official/config.yaml
+++ b/external/tks_api_official/config.yaml
@@ -2,87 +2,91 @@ base_clearance_fee: 3100
 base_util_fee: 20000
 etc_util_coeff_base: 1.0
 ctp_util_coeff_base: 1.2
-excise_rates:
-  gasoline: 58
-  diesel: 58
-  electric: 0
-  hybrid: 58
-recycling_factors:
-  default:
-    gasoline: 1.0
-    diesel: 1.1
-    electric: 0.3
-    hybrid: 1.0
-  adjustments:
-    "5-7":
-      gasoline: 0.26
-      diesel: 0.26
-      electric: 0.26
-      hybrid: 0.26
-age_groups:
-  new:
-    gasoline:
-      rate_per_cc: 2.5
-      min_duty: 0
-    diesel:
-      rate_per_cc: 2.7
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 1.8
-      min_duty: 2000
-  "1-3":
-    gasoline:
-      rate_per_cc: 3.0
-      min_duty: 0
-    diesel:
-      rate_per_cc: 3.2
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.0
-      min_duty: 2000
-  "3-5":
-    gasoline:
-      rate_per_cc: 4.0
-      min_duty: 0
-    diesel:
-      rate_per_cc: 4.2
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.5
-      min_duty: 2500
-  "5-7":
-    gasoline:
-      rate_per_cc: 4.8
-      min_duty: 0
-    diesel:
-      rate_per_cc: 5.0
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 2.0
-      min_duty: 2500
-  over_7:
-    gasoline:
-      rate_per_cc: 5.5
-      min_duty: 0
-    diesel:
-      rate_per_cc: 5.8
-      min_duty: 0
-    electric:
-      rate_per_cc: 0
-      min_duty: 1000
-    hybrid:
-      rate_per_cc: 3.0
-      min_duty: 3000
+vehicle_types:
+  passenger: &passenger
+    excise_rates:
+      gasoline: 58
+      diesel: 58
+      electric: 0
+      hybrid: 58
+    recycling_factors:
+      default:
+        gasoline: 1.0
+        diesel: 1.1
+        electric: 0.3
+        hybrid: 1.0
+      adjustments:
+        "5-7":
+          gasoline: 0.26
+          diesel: 0.26
+          electric: 0.26
+          hybrid: 0.26
+    age_groups:
+      new:
+        gasoline:
+          rate_per_cc: 2.5
+          min_duty: 0
+        diesel:
+          rate_per_cc: 2.7
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 1.8
+          min_duty: 2000
+      "1-3":
+        gasoline:
+          rate_per_cc: 3.0
+          min_duty: 0
+        diesel:
+          rate_per_cc: 3.2
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.0
+          min_duty: 2000
+      "3-5":
+        gasoline:
+          rate_per_cc: 4.0
+          min_duty: 0
+        diesel:
+          rate_per_cc: 4.2
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.5
+          min_duty: 2500
+      "5-7":
+        gasoline:
+          rate_per_cc: 4.8
+          min_duty: 0
+        diesel:
+          rate_per_cc: 5.0
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 2.0
+          min_duty: 2500
+      over_7:
+        gasoline:
+          rate_per_cc: 5.5
+          min_duty: 0
+        diesel:
+          rate_per_cc: 5.8
+          min_duty: 0
+        electric:
+          rate_per_cc: 0
+          min_duty: 1000
+        hybrid:
+          rate_per_cc: 3.0
+          min_duty: 3000
+  truck:
+    <<: *passenger
 vat_rate: 0.2

--- a/tests/test_customs_calculator.py
+++ b/tests/test_customs_calculator.py
@@ -26,6 +26,14 @@ spec.loader.exec_module(currency_mod)  # type: ignore[attr-defined]
 to_rub = currency_mod.to_rub
 
 spec = importlib.util.spec_from_file_location(
+    "tariff.personal_rates", ROOT / "bot_alista" / "tariff" / "personal_rates.py"
+)
+pr_mod = importlib.util.module_from_spec(spec)
+sys.modules["tariff.personal_rates"] = pr_mod
+spec.loader.exec_module(pr_mod)  # type: ignore[attr-defined]
+PERSONAL_CLEARANCE_FEE = pr_mod.CUSTOMS_CLEARANCE_FEE_RUB
+
+spec = importlib.util.spec_from_file_location(
     "services.customs_calculator", SERVICES_PATH / "customs_calculator.py"
 )
 cc_mod = importlib.util.module_from_spec(spec)
@@ -52,6 +60,12 @@ if hasattr(cc_mod, "VehicleOwnerType"):
 else:  # pragma: no cover - fallback
     class OwnerType(str, Enum):
         INDIVIDUAL = "individual"
+
+if hasattr(cc_mod, "VehicleType"):
+    VehicleType = cc_mod.VehicleType
+else:  # pragma: no cover - fallback
+    class VehicleType(str, Enum):
+        PASSENGER = "passenger"
 
 if hasattr(cc_mod, "WrongParamException"):
     WrongParamException = cc_mod.WrongParamException
@@ -83,6 +97,7 @@ def vehicle_usd() -> dict:
         "price": 10000,
         "owner_type": OwnerType("individual"),
         "currency": "USD",
+        "vehicle_type": VehicleType("passenger"),
     }
 
 
@@ -93,11 +108,12 @@ def test_calculate_ctp_returns_expected_total(calc: CustomsCalculator, vehicle_u
     price_rub = to_rub(vehicle_usd["price"], "USD")
 
     tariffs = TARIFFS
+    vt = tariffs["vehicle_types"]["passenger"]
     min_duty_rub = to_rub(0.44, "EUR") * vehicle_usd["engine_capacity"]
     duty_rub = max(price_rub * 0.2, min_duty_rub)
-    excise_rub = tariffs["excise_rates"]["gasoline"] * vehicle_usd["power"]
+    excise_rub = vt["excise_rates"]["gasoline"] * vehicle_usd["power"]
     util_rub = tariffs["base_util_fee"] * tariffs["ctp_util_coeff_base"]
-    recycling_rub = RECYCLING_FEE_BASE_RATE * tariffs["recycling_factors"]["adjustments"]["5-7"]["gasoline"]
+    recycling_rub = RECYCLING_FEE_BASE_RATE * vt["recycling_factors"]["adjustments"]["5-7"]["gasoline"]
     price_limit_map = [
         (200_000, 1_067),
         (450_000, 2_134),
@@ -124,12 +140,66 @@ def test_calculate_ctp_returns_expected_total(calc: CustomsCalculator, vehicle_u
 def test_calculate_etc_includes_vehicle_price(calc: CustomsCalculator, vehicle_usd: dict):
     calc.set_vehicle_details(**vehicle_usd)
     ctp = calc.calculate_ctp()
+    calc.set_vehicle_details(**vehicle_usd)
     etc = calc.calculate_etc()
-    assert etc["etc_rub"] == pytest.approx(
-        etc["vehicle_price_rub"] + etc["total_rub"]
+    rate_rub = to_rub(
+        TARIFFS["vehicle_types"]["passenger"]["age_groups"]["5-7"]["gasoline"]["rate_per_cc"],
+        "EUR",
     )
+    expected_duty = max(rate_rub * vehicle_usd["engine_capacity"], 0)
+    assert etc["duty_rub"] == pytest.approx(expected_duty)
+    assert etc["excise_rub"] == 0.0
+    assert etc["vat_rub"] == 0.0
+    assert etc["etc_rub"] == pytest.approx(etc["price_rub"] + etc["total_rub"])
     # ensure previous result not mutated
     assert ctp["total_rub"] == pytest.approx(ctp["total_rub"])
+
+
+def test_calculate_auto_selects_higher(calc: CustomsCalculator, vehicle_usd: dict):
+    params = dict(vehicle_usd)
+    params["owner_type"] = OwnerType("company")
+    calc.set_vehicle_details(**params)
+    auto = calc.calculate_auto()
+    calc.set_vehicle_details(**params)
+    ctp = calc.calculate_ctp()
+    calc.set_vehicle_details(**params)
+    etc = calc.calculate_etc()
+    expected = ctp if ctp["total_rub"] >= etc["total_rub"] else etc
+    assert auto == expected
+
+
+def test_calculate_personal_rates(calc: CustomsCalculator):
+    params = {
+        "age": AgeGroup("1-3"),
+        "engine_capacity": 2500,
+        "engine_type": EngineType("gasoline"),
+        "power": 150,
+        "price": 20000,
+        "owner_type": OwnerType("individual"),
+        "currency": "USD",
+        "vehicle_type": VehicleType("passenger"),
+    }
+    calc.set_vehicle_details(**params)
+    res = calc.calculate_auto()
+
+    duty_rub = to_rub(2500 * 5.5, "EUR")
+    recycling_rub = RECYCLING_FEE_BASE_RATE * TARIFFS["vehicle_types"]["passenger"]["recycling_factors"]["default"]["gasoline"]
+    util_rub = TARIFFS["base_util_fee"]
+    expected_total = duty_rub + util_rub + recycling_rub + PERSONAL_CLEARANCE_FEE
+
+    assert res["duty_rub"] == pytest.approx(duty_rub)
+    assert res["vat_rub"] == 0.0
+    assert res["total_rub"] == pytest.approx(expected_total)
+
+
+def test_vehicle_type_truck(calc: CustomsCalculator, vehicle_usd: dict):
+    params = dict(vehicle_usd)
+    params["vehicle_type"] = VehicleType("truck")
+    calc.set_vehicle_details(**params)
+    truck_res = calc.calculate_ctp()
+    calc.set_vehicle_details(**vehicle_usd)
+    pass_res = calc.calculate_ctp()
+    assert truck_res == pass_res
 
 
 def test_state_reset_between_calls(calc: CustomsCalculator, vehicle_usd: dict):


### PR DESCRIPTION
## Summary
- add personal-use tariff path using official per-cc table and clearance fee
- invoke personal path for individuals while retaining ETC/CTP choice for companies
- cover personal-rate scenario and auto-selection for companies in tests

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae5127de4832b9a8daf962cdcc898