### PR TITLE
Load clearance tax ranges from tariffs

### DIFF
--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -18,15 +18,6 @@ logger = logging.getLogger(__name__)
 
 BASE_VAT = 0.2
 RECYCLING_FEE_BASE_RATE = 20_000
-CUSTOMS_CLEARANCE_TAX_RANGES = [
-    (200_000, 1_067),
-    (450_000, 2_134),
-    (1_200_000, 4_269),
-    (3_000_000, 11_746),
-    (5_000_000, 16_524),
-    (7_000_000, 20_000),
-    (float("inf"), 30_000),
-]
 
 
 class WrongParamException(Exception):
@@ -159,13 +150,15 @@ class CustomsCalculator:
     # Fee helpers
     # ------------------------------------------------------------------
     def calculate_clearance_tax(self) -> float:
+        """Return clearance tax based on price ranges defined in tariffs."""
         v = self._require_vehicle()
         price = v.price_rub
-        for limit, tax in CUSTOMS_CLEARANCE_TAX_RANGES:
+        ranges = self.tariffs["clearance_tax_ranges"]
+        for limit, tax in ranges:
             if price <= limit:
                 logger.info("Customs clearance tax: %s RUB", tax)
                 return float(tax)
-        return float(CUSTOMS_CLEARANCE_TAX_RANGES[-1][1])
+        return float(ranges[-1][1])
 
     def calculate_recycling_fee(self) -> float:
         v = self._require_vehicle()

--- a/external/tks_api_official/config.yaml
+++ b/external/tks_api_official/config.yaml
@@ -1,7 +1,15 @@
-base_clearance_fee: 3100
 base_util_fee: 20000
 etc_util_coeff_base: 1.0
 ctp_util_coeff_base: 1.2
+# Clearance fees are determined solely by the price ranges below.
+clearance_tax_ranges:
+  - [200000, 1067]
+  - [450000, 2134]
+  - [1200000, 4269]
+  - [3000000, 11746]
+  - [5000000, 16524]
+  - [7000000, 20000]
+  - [.inf, 30000]
 vehicle_types:
   passenger: &passenger
     excise_rates:


### PR DESCRIPTION
## Summary
- remove hardcoded clearance tax table and read ranges from tariff config
- drop unused `base_clearance_fee` and document range-based fees in config
- test that clearance tax uses tariff ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf42e008c832ba5293b5b0490ce67