### PR TITLE
refactor: replace state filter for start command

### DIFF
--- a/bot_alista/handlers/menu.py
+++ b/bot_alista/handlers/menu.py
@@ -1,12 +1,12 @@
 from aiogram import Router, types
-from aiogram.filters import Command
+from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from bot_alista.keyboards.main_menu import main_menu
 
 router = Router()
 
 
-@router.message(Command("start"), state="*")
+@router.message(Command("start"), StateFilter("*"))
 async def cmd_start(message: types.Message, state: FSMContext):
     await state.clear()
     await message.answer(


### PR DESCRIPTION
## Summary
- replace unsupported `state="*"` filter with `StateFilter` for the `/start` handler

## Testing
- `pytest`
- `BOT_TOKEN=dummy python -m bot_alista.main` *(fails: unsupported keyword argument in another handler)*

------
https://chatgpt.com/codex/tasks/task_e_68aafdd79838832b9d3fdc8f43e118bc