### PR TITLE
refactor: replace state filter for start command

### DIFF
--- a/bot_alista/handlers/menu.py
+++ b/bot_alista/handlers/menu.py
@@ -1,12 +1,12 @@
 from aiogram import Router, types
-from aiogram.filters import Command
+from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from bot_alista.keyboards.main_menu import main_menu
 
 router = Router()
 
 
-@router.message(Command("start"), state="*")
+@router.message(Command("start"), StateFilter("*"))
 async def cmd_start(message: types.Message, state: FSMContext):
     await state.clear()
     await message.answer(

--- a/bot_alista/handlers/menu_navigation.py
+++ b/bot_alista/handlers/menu_navigation.py
@@ -1,5 +1,6 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
+from aiogram.filters import StateFilter
 
 from bot_alista.constants import BTN_MAIN_MENU, BTN_BACK, BTN_EXIT
 from bot_alista.utils.reset import reset_to_menu
@@ -12,7 +13,7 @@ async def go_main_menu(message: types.Message, state: FSMContext):
     await reset_to_menu(message, state)
 
 
-@router.message(F.text == BTN_BACK, state=None)
+@router.message(F.text == BTN_BACK, StateFilter(None))
 async def go_back(message: types.Message, state: FSMContext):
     # Просто возвращаем в главное меню
     await reset_to_menu(message, state)


### PR DESCRIPTION
## Summary
- replace unsupported `state="*"` filter with `StateFilter` for the `/start` handler
- replace unsupported `state=None` filter with `StateFilter` for the back button handler

## Testing
- `pytest`
- `BOT_TOKEN=dummy python -m bot_alista.main` *(fails: Token is invalid!)*

------
https://chatgpt.com/codex/tasks/task_e_68aafdd79838832b9d3fdc8f43e118bc