### PR TITLE
Improve utilization fee handling

### DIFF
--- a/bot_alista/formatting.py
+++ b/bot_alista/formatting.py
@@ -37,14 +37,17 @@ def format_result_message(
         rates: mapping like {"EUR": 92.86, "USD": 79.87, ...} (RUB per 1 unit)
         meta: extra info (e.g., person/usage, engine, age bucket info, notes)
         core: result from calc_breakdown_with_mode(...)
-        util_fee_rub: utilization fee in RUB
+        util_fee_rub: utilization fee in RUB (ignored if ``core`` contains it)
 
     Returns:
         A formatted Telegram message string.
     """
     br = core["breakdown"]
     total_no_util = br["total_rub"]
-    total_with_util = round(total_no_util + util_fee_rub, 2)
+    util_fee_rub = br.get("util_rub", util_fee_rub)
+    total_with_util = br.get(
+        "total_with_util_rub", round(total_no_util + util_fee_rub, 2)
+    )
 
     usd_rate = rates.get("USD")
     eur_rate = rates.get("EUR")

--- a/bot_alista/tariff/engine.py
+++ b/bot_alista/tariff/engine.py
@@ -326,6 +326,20 @@ def calc_breakdown_with_mode(
             2,
         )
 
+        util_rub = calc_util_rub(
+            person_type="individual",
+            usage="personal",
+            engine_cc=engine_cc,
+            fuel="ice",
+            vehicle_kind="passenger",
+            age_years=age_years,
+            date_decl=date.today(),
+            avg_vehicle_cost_rub=None,
+            actual_costs_rub=None,
+            config=UTIL_CONFIG,
+        )
+        total_with_util = round(total_rub + util_rub, 2)
+
         return {
             "inputs": {
                 "person_type": person_type,
@@ -342,6 +356,8 @@ def calc_breakdown_with_mode(
                 "customs_value_rub": customs_value_rub,
                 **core,
                 "total_rub": total_rub,
+                "util_rub": util_rub,
+                "total_with_util_rub": total_with_util,
             },
             "rates_used": {
                 "mode": "individual_personal_rate_table",
@@ -366,6 +382,22 @@ def calc_breakdown_with_mode(
     corp["breakdown"]["clearance_fee_rub"] = fee_rub
     corp["breakdown"]["total_rub"] = round(
         corp["breakdown"]["total_rub"] + fee_rub, 2
+    )
+    util_rub = calc_util_rub(
+        person_type=person_type,
+        usage="personal" if usage_type == "personal" else "commercial",
+        engine_cc=engine_cc,
+        fuel="ice",
+        vehicle_kind="passenger",
+        age_years=age_years,
+        date_decl=date.today(),
+        avg_vehicle_cost_rub=None,
+        actual_costs_rub=None,
+        config=UTIL_CONFIG,
+    )
+    corp["breakdown"]["util_rub"] = util_rub
+    corp["breakdown"]["total_with_util_rub"] = round(
+        corp["breakdown"]["total_rub"] + util_rub, 2
     )
     corp.setdefault("rates_used", {}).update({"mode": "corporate_alta"})
     corp.setdefault("notes", []).append(

--- a/bot_alista/tariff/util_fee.py
+++ b/bot_alista/tariff/util_fee.py
@@ -237,14 +237,14 @@ def calc_util_rub(
             applicable_rule = rule
             applicable_date = rule_date
 
-    if (
-        applicable_rule
-        and applicable_rule.get("formula") == "ed_plus_half_diff"
-        and avg_vehicle_cost_rub is not None
-        and actual_costs_rub is not None
-    ):
+    if applicable_rule and applicable_rule.get("formula") == "ed_plus_half_diff":
+        if avg_vehicle_cost_rub is None or actual_costs_rub is None:
+            raise ValueError("avg_vehicle_cost_rub and actual_costs_rub are required")
+        if avg_vehicle_cost_rub < 0 or actual_costs_rub < 0:
+            raise ValueError("Cost values must be non-negative")
+        diff = max(avg_vehicle_cost_rub - actual_costs_rub, 0)
         factor = float(applicable_rule.get("half_diff_factor", 0.5))
-        result = us_ed + (avg_vehicle_cost_rub - actual_costs_rub) * factor
+        result = us_ed + diff * factor
     else:
         result = us_ed
 

--- a/tests/test_util_fee.py
+++ b/tests/test_util_fee.py
@@ -1,0 +1,51 @@
+from datetime import date
+import copy
+import pytest
+from bot_alista.tariff.util_fee import calc_util_rub, UTIL_CONFIG
+
+
+def test_calc_util_rub_clamps_negative_diff():
+    cfg = copy.deepcopy(UTIL_CONFIG)
+    res = calc_util_rub(
+        person_type="individual",
+        usage="personal",
+        engine_cc=1500,
+        fuel="ice",
+        vehicle_kind="passenger",
+        age_years=2.0,
+        date_decl=date(2025, 6, 1),
+        avg_vehicle_cost_rub=500000.0,
+        actual_costs_rub=600000.0,
+        config=cfg,
+    )
+    assert res == 3400.0
+
+
+def test_calc_util_rub_requires_non_negative_costs():
+    cfg = copy.deepcopy(UTIL_CONFIG)
+    with pytest.raises(ValueError):
+        calc_util_rub(
+            person_type="individual",
+            usage="personal",
+            engine_cc=1500,
+            fuel="ice",
+            vehicle_kind="passenger",
+            age_years=2.0,
+            date_decl=date(2025, 6, 1),
+            avg_vehicle_cost_rub=-1.0,
+            actual_costs_rub=1000.0,
+            config=cfg,
+        )
+    with pytest.raises(ValueError):
+        calc_util_rub(
+            person_type="individual",
+            usage="personal",
+            engine_cc=1500,
+            fuel="ice",
+            vehicle_kind="passenger",
+            age_years=2.0,
+            date_decl=date(2025, 6, 1),
+            avg_vehicle_cost_rub=1000.0,
+            actual_costs_rub=None,
+            config=cfg,
+        )


### PR DESCRIPTION
## Summary
- compute and include utilization fee totals in tariff engine breakdowns
- derive util fee via calc_util_rub in CustomsCalculator
- validate cost inputs in util fee logic and add dedicated tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abd03cb184832bb80258b266cbc057