### PR TITLE
Refine customs calculator engine and duty logic

### DIFF
--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -422,11 +422,13 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             age_group = "over_7"
 
         calc = CustomsCalculator()
+        calc.tariffs.setdefault("ctp", {"duty_rate": 0.2, "min_per_cc_eur": 0.44})
         calc.set_vehicle_details(
             age=age_group,
             engine_capacity=engine_cc,
             engine_type=fuel_type,
             power=engine_hp,
+            production_year=year,
             price=amount,
             owner_type=person_type,
             currency=currency_code,


### PR DESCRIPTION
## Summary
- allow hybrids to specify engine displacement and require production year
- read CTP duty parameters from tariff config and compute util fee from factual age
- avoid state mutation in auto mode and expand test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abd793ddf8832baa7a281e22b164f1