### PR TITLE
Resolve merge conflicts for date-aware customs conversions

### DIFF
--- a/bot_alista/clearance_fee.py
+++ b/bot_alista/clearance_fee.py
@@ -1,4 +1,8 @@
-"""Shared customs clearance fee ladder and helpers."""
+"""Shared customs clearance fee ladder and helpers.
+
+All clearance fees are rounded to the nearest whole ruble as required by the
+official schedules.
+"""
 
 from __future__ import annotations
 
@@ -18,15 +22,15 @@ CLEARANCE_FEE_RANGES: Tuple[Tuple[float, float], ...] = (
 def calc_clearance_fee_rub(
     customs_value_rub: float,
     ranges: Sequence[Tuple[float, float]] = CLEARANCE_FEE_RANGES,
-) -> float:
-    """Return clearance fee based on customs value."""
+) -> int:
+    """Return clearance fee based on customs value as integer rubles."""
     v = float(customs_value_rub)
     if v <= 0:
         raise ValueError("Customs value must be positive")
     for limit, fee in ranges:
         if v <= limit:
-            return float(fee)
-    return float(ranges[-1][1])
+            return int(round(fee))
+    return int(round(ranges[-1][1]))
 
 
 __all__ = ["CLEARANCE_FEE_RANGES", "calc_clearance_fee_rub"]

--- a/bot_alista/services/currency.py
+++ b/bot_alista/services/currency.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 """Utility helpers for currency conversion."""
 
-try:
+from datetime import date
+from typing import Dict
+
+import requests
+
+try:  # pragma: no cover - optional dependency
     from currency_converter_free import CurrencyConverter
 except Exception:  # pragma: no cover - fallback name
     from currency_converter_free import CurrencyConverter
@@ -11,6 +16,9 @@ _converter: CurrencyConverter | None = None
 _FALLBACK_RATES = {"USD": 0.9, "KRW": 0.0007, "RUB": 0.01}
 _EUR_TO_RUB = 1 / _FALLBACK_RATES["RUB"]
 
+FTS_URL = "https://customs.example/rates/{date}"
+_fts_cache: Dict[str, Dict[str, float]] = {}
+
 
 def _get_converter() -> CurrencyConverter:
     global _converter
@@ -18,7 +26,28 @@ def _get_converter() -> CurrencyConverter:
         _converter = CurrencyConverter()
     return _converter
 
-def to_eur(amount: float, currency: str, eur_rate: float | None = None) -> float:
+
+def _get_fts_rates(rate_date: date) -> Dict[str, float]:
+    """Fetch daily rates from the FTS endpoint with simple caching."""
+
+    key = rate_date.isoformat()
+    if key in _fts_cache:
+        return _fts_cache[key]
+
+    resp = requests.get(FTS_URL.format(date=key), timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    rates = {k.upper(): float(v) for k, v in data.items()}
+    _fts_cache[key] = rates
+    return rates
+
+def to_eur(
+    amount: float,
+    currency: str,
+    eur_rate: float | None = None,
+    *,
+    rate_date: date | None = None,
+) -> float:
     """Convert ``amount`` from ``currency`` to EUR.
 
     ``eur_rate`` may be provided to convert values expressed in RUB without
@@ -36,6 +65,16 @@ def to_eur(amount: float, currency: str, eur_rate: float | None = None) -> float
     code = currency.upper()
     if code == "EUR":
         return float(amount)
+    if rate_date is not None:
+        rates = _get_fts_rates(rate_date)
+        eur = rates.get("EUR")
+        src = rates.get(code)
+        if eur is None or (src is None and code != "RUB"):
+            raise ValueError(f"Unsupported currency: {currency}")
+        if code == "RUB":
+            rate = eur
+            return float(amount) / rate
+        return float(amount) * src / eur
     if code == "RUB" and eur_rate is not None:
         return float(amount) / eur_rate
 
@@ -51,7 +90,7 @@ def to_eur(amount: float, currency: str, eur_rate: float | None = None) -> float
         return float(amount) * rate
 
 
-def to_rub(amount: float, currency: str) -> float:
+def to_rub(amount: float, currency: str, *, rate_date: date | None = None) -> float:
     """Convert ``amount`` from ``currency`` to RUB.
 
     The function first tries :mod:`currency_converter_free` and falls back to
@@ -66,6 +105,12 @@ def to_rub(amount: float, currency: str) -> float:
     code = currency.upper()
     if code == "RUB":
         return float(amount)
+    if rate_date is not None:
+        rates = _get_fts_rates(rate_date)
+        rate = rates.get(code)
+        if rate is None:
+            raise ValueError(f"Unsupported currency: {currency}")
+        return float(amount) * rate
     try:
         converter = _get_converter()
         return float(converter.convert(amount, code, "RUB"))

--- a/bot_alista/services/customs_calculator.py
+++ b/bot_alista/services/customs_calculator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from datetime import date
 import copy
+from decimal import Decimal, ROUND_HALF_UP
 
 from tabulate import tabulate
 
@@ -26,6 +27,11 @@ logger = logging.getLogger(__name__)
 
 BASE_VAT = 0.2
 RECYCLING_FEE_BASE_RATE = 20_000
+
+
+def _round2(value: float) -> float:
+    """Round monetary values to two decimals using bankers rounding."""
+    return float(Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
 
 
 class WrongParamException(Exception):
@@ -87,8 +93,10 @@ class CustomsCalculator:
         config_path: str | Path | None = None,
         *,
         tariffs: Optional[Dict[str, Any]] = None,
+        rate_date: date | None = None,
     ) -> None:
         self.tariffs = tariffs or get_tariffs(config_path)
+        self.rate_date = rate_date
         self.reset_fields()
         self._last_result: Dict[str, float] | None = None
 
@@ -134,8 +142,16 @@ class CustomsCalculator:
         elif engine_capacity < 800 or engine_capacity > 8000:
             raise WrongParamException("engine_capacity out of range")
 
+        if power <= 0:
+            raise WrongParamException("power must be positive")
+        if price <= 0:
+            raise WrongParamException("price must be positive")
+        current_year = date.today().year
+        if production_year < 1900 or production_year > current_year:
+            raise WrongParamException("production_year out of range")
+
         try:
-            price_rub = to_rub(price, currency)
+            price_rub = to_rub(price, currency, rate_date=self.rate_date)
         except Exception as exc:
             raise WrongParamException(str(exc))
 
@@ -199,25 +215,43 @@ class CustomsCalculator:
             config=util_cfg,
         )
 
-    def calculate_clearance_tax(self) -> float:
-        """Return clearance tax based on price ranges defined in tariffs."""
+    def calculate_clearance_tax(self) -> int:
+        """Return clearance tax based on tariffs as whole rubles."""
         v = self._require_vehicle()
         price = v.price_rub
         ranges = self.tariffs.get("clearance_tax_ranges", CLEARANCE_FEE_RANGES)
         fee = calc_clearance_fee_rub(price, ranges)
+        # calc_clearance_fee_rub already rounds to whole rubles
         logger.info("Customs clearance tax: %s RUB", fee)
         return fee
 
     def calculate_recycling_fee(self) -> float:
         v = self._require_vehicle()
         vt = self._vehicle_tariffs(v)
-        factors = vt["recycling_factors"]
-        default = factors.get("default", {})
-        adjustments = factors.get("adjustments", {}).get(v.age.value, {})
-        engine_factor = adjustments.get(
-            v.engine_type.value, default.get(v.engine_type.value, 1.0)
-        )
-        fee = RECYCLING_FEE_BASE_RATE * engine_factor
+        cfg = vt.get("recycling_fee")
+        if cfg:
+            base = cfg.get("base_rate", RECYCLING_FEE_BASE_RATE)
+            engine_factor = cfg.get("engine_factors", {}).get(
+                v.engine_type.value, 1.0
+            )
+            age_factor = (
+                cfg.get("age_adjustments", {})
+                .get(v.age.value, {})
+                .get(v.engine_type.value, 1.0)
+            )
+            owner_factor = cfg.get("owner_multipliers", {}).get(
+                v.owner_type.value, 1.0
+            )
+            fee = base * engine_factor * age_factor * owner_factor
+        else:  # backward compatibility with older configs
+            factors = vt.get("recycling_factors", {})
+            default = factors.get("default", {})
+            adjustments = factors.get("adjustments", {}).get(v.age.value, {})
+            engine_factor = adjustments.get(
+                v.engine_type.value, default.get(v.engine_type.value, 1.0)
+            )
+            fee = RECYCLING_FEE_BASE_RATE * engine_factor
+        fee = _round2(fee)
         logger.info("Recycling fee: %s RUB", fee)
         return float(fee)
 
@@ -245,24 +279,26 @@ class CustomsCalculator:
             min_cc_eur = ctp_cfg["min_per_cc_eur"]
         except KeyError as exc:
             raise WrongParamException(f"missing CTP tariff parameter: {exc}")
-        min_duty_per_cc = to_rub(min_cc_eur, "EUR")
-        duty_rub = max(price_rub * duty_rate, min_duty_per_cc * v.engine_capacity)
+        min_duty_per_cc = to_rub(min_cc_eur, "EUR", rate_date=self.rate_date)
+        duty_rub = _round2(max(price_rub * duty_rate, min_duty_per_cc * v.engine_capacity))
 
-        excise = self.calculate_excise()
-        recycling_fee = self.calculate_recycling_fee()
-        vat = (price_rub + duty_rub + excise) * vat_rate
+        excise = _round2(self.calculate_excise())
+        recycling_fee = _round2(self.calculate_recycling_fee())
+        vat = _round2((price_rub + duty_rub + excise) * vat_rate)
 
-        clearance_fee = self.calculate_clearance_tax()
+        clearance_fee = int(self.calculate_clearance_tax())
         decl_date = self.tariffs.get("util_date", date(2024, 1, 1))
         if isinstance(decl_date, str):
             decl_date = date.fromisoformat(decl_date)
         age_years = compute_actual_age_years(v.production_year, decl_date)
-        util_fee = self._calculate_util_fee(v, age_years, decl_date)
+        util_fee = _round2(self._calculate_util_fee(v, age_years, decl_date))
 
-        total_pay = duty_rub + excise + vat + clearance_fee + util_fee + recycling_fee
+        total_pay = _round2(
+            duty_rub + excise + vat + clearance_fee + util_fee + recycling_fee
+        )
         res = {
             "mode": "CTP",
-            "price_rub": price_rub,
+            "price_rub": _round2(price_rub),
             "duty_rub": duty_rub,
             "excise_rub": excise,
             "vat_rub": vat,
@@ -278,23 +314,25 @@ class CustomsCalculator:
         v = self._require_vehicle()
         vt = self._vehicle_tariffs(v)
         cfg = vt["age_groups"][v.age.value][v.engine_type.value]
-        rate_per_cc = to_rub(cfg["rate_per_cc"], "EUR")
+        rate_per_cc = to_rub(cfg["rate_per_cc"], "EUR", rate_date=self.rate_date)
         min_duty = cfg.get("min_duty", 0)
-        min_duty_rub = to_rub(min_duty, "EUR") if min_duty else 0
-        duty_rub = max(rate_per_cc * v.engine_capacity, min_duty_rub)
+        min_duty_rub = (
+            to_rub(min_duty, "EUR", rate_date=self.rate_date) if min_duty else 0
+        )
+        duty_rub = _round2(max(rate_per_cc * v.engine_capacity, min_duty_rub))
 
-        clearance_fee = self.calculate_clearance_tax()
+        clearance_fee = int(self.calculate_clearance_tax())
         decl_date = self.tariffs.get("util_date", date(2024, 1, 1))
         if isinstance(decl_date, str):
             decl_date = date.fromisoformat(decl_date)
         age_years = compute_actual_age_years(v.production_year, decl_date)
-        util_fee = self._calculate_util_fee(v, age_years, decl_date)
-        recycling_fee = self.calculate_recycling_fee()
+        util_fee = _round2(self._calculate_util_fee(v, age_years, decl_date))
+        recycling_fee = _round2(self.calculate_recycling_fee())
 
-        total_pay = duty_rub + clearance_fee + util_fee + recycling_fee
+        total_pay = _round2(duty_rub + clearance_fee + util_fee + recycling_fee)
         res = {
             "mode": "ETC",
-            "price_rub": v.price_rub,
+            "price_rub": _round2(v.price_rub),
             "duty_rub": duty_rub,
             "excise_rub": 0.0,
             "vat_rub": 0.0,
@@ -302,8 +340,8 @@ class CustomsCalculator:
             "util_rub": util_fee,
             "recycling_rub": recycling_fee,
             "total_rub": total_pay,
-            "vehicle_price_rub": v.price_rub,
-            "etc_rub": v.price_rub + total_pay,
+            "vehicle_price_rub": _round2(v.price_rub),
+            "etc_rub": _round2(v.price_rub + total_pay),
         }
         self._last_result = res
         return res

--- a/bot_alista/tariff/engine.py
+++ b/bot_alista/tariff/engine.py
@@ -458,15 +458,14 @@ def calc_breakdown_rules(
         fee_rub = calc_clearance_fee_rub(customs_value_rub)
         total_no_util = round(core["duty_rub"] + fee_rub, 2)
 
-        # UTIL uses factual age (not the user's button)
-        util_age_years = 4.0 if actual_age > 3.0 else 2.0
+        # UTIL uses factual age directly
         util_rub = calc_util_rub(
             person_type="individual",
             usage="personal",
             engine_cc=int(engine_cc or 0),
             fuel=util_fuel,
             vehicle_kind="passenger",
-            age_years=util_age_years,
+            age_years=actual_age,
             date_decl=decl_date,
             avg_vehicle_cost_rub=None,
             actual_costs_rub=None,

--- a/external/tks_api_official/config.yaml
+++ b/external/tks_api_official/config.yaml
@@ -17,18 +17,25 @@ vehicle_types:
       diesel: 58
       electric: 0
       hybrid: 58
-    recycling_factors:
-      default:
+    recycling_fee:
+      # Base recycling fee before multipliers
+      base_rate: 20000
+      # Engine type multipliers
+      engine_factors:
         gasoline: 1.0
         diesel: 1.1
         electric: 0.3
         hybrid: 1.0
-      adjustments:
+      # Age-specific multipliers applied on top of engine factors
+      age_adjustments:
         "5-7":
           gasoline: 0.26
           diesel: 0.26
           electric: 0.26
           hybrid: 0.26
+      # Optional owner-type multipliers
+      owner_multipliers:
+        company: 1.2
     age_groups:
       new:
         gasoline:

--- a/tests/test_clearance_fee.py
+++ b/tests/test_clearance_fee.py
@@ -1,0 +1,12 @@
+from bot_alista.clearance_fee import calc_clearance_fee_rub
+import pytest
+
+
+def test_clearance_fee_returns_int():
+    assert isinstance(calc_clearance_fee_rub(150000), int)
+    assert calc_clearance_fee_rub(150000) == 1067
+
+
+def test_clearance_fee_negative_value():
+    with pytest.raises(ValueError):
+        calc_clearance_fee_rub(-1)

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+from datetime import date
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES_PATH = ROOT / "bot_alista" / "services"
+
+spec = importlib.util.spec_from_file_location(
+    "services.currency", SERVICES_PATH / "currency.py"
+)
+currency_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(currency_mod)  # type: ignore[attr-defined]
+
+to_rub = currency_mod.to_rub
+to_eur = currency_mod.to_eur
+
+
+def test_to_rub_uses_fts_rate(monkeypatch):
+    monkeypatch.setattr(
+        currency_mod,
+        "_get_fts_rates",
+        lambda d: {"USD": 90.0, "EUR": 100.0},
+    )
+    assert to_rub(2, "USD", rate_date=date(2024, 1, 1)) == 180.0
+    assert to_eur(90, "USD", rate_date=date(2024, 1, 1)) == pytest.approx(81.0)
+    assert to_eur(100, "RUB", rate_date=date(2024, 1, 1)) == 1.0

--- a/tests/test_tariff_engine.py
+++ b/tests/test_tariff_engine.py
@@ -70,6 +70,36 @@ def test_calc_breakdown_rules_company_commercial():
     assert any("UL by CSV" in note for note in result["notes"])
 
 
+def test_util_fee_varies_with_age():
+    older = calc_breakdown_rules(
+        person_type="individual",
+        usage_type="personal",
+        customs_value_eur=10000,
+        eur_rub_rate=100.0,
+        engine_cc=2500,
+        engine_hp=None,
+        production_year=2021,
+        age_choice_over3=True,
+        fuel_type="Бензин",
+        decl_date=date(2025, 1, 1),
+    )
+    newer = calc_breakdown_rules(
+        person_type="individual",
+        usage_type="personal",
+        customs_value_eur=10000,
+        eur_rub_rate=100.0,
+        engine_cc=2500,
+        engine_hp=None,
+        production_year=2022,
+        age_choice_over3=True,
+        fuel_type="Бензин",
+        decl_date=date(2025, 1, 1),
+    )
+    util_old = older["breakdown"]["util_rub"]
+    util_new = newer["breakdown"]["util_rub"]
+    assert util_old > util_new
+
+
 def test_calc_import_breakdown_validation_errors_negative():
     with pytest.raises(ValueError):
         calc_import_breakdown(

--- a/tests/test_tariffs.py
+++ b/tests/test_tariffs.py
@@ -1,0 +1,57 @@
+import sys
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES_PATH = ROOT / "bot_alista" / "services"
+
+spec = importlib.util.spec_from_file_location(
+    "services.tariffs", SERVICES_PATH / "tariffs.py"
+)
+tariffs_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tariffs_mod)  # type: ignore[attr-defined]
+get_tariffs = tariffs_mod.get_tariffs
+CONFIG = ROOT / "external" / "tks_api_official" / "config.yaml"
+
+
+def reset_cache():
+    tariffs_mod._cache = None
+    tariffs_mod._cache_date = None
+
+
+def test_get_tariffs_env_override(monkeypatch):
+    reset_cache()
+    monkeypatch.setenv("CUSTOMS_TARIFF_DATA", "foo: 1")
+    data = get_tariffs(path=CONFIG)
+    assert data["foo"] == 1
+    monkeypatch.delenv("CUSTOMS_TARIFF_DATA")
+
+
+def test_get_tariffs_network_success(monkeypatch):
+    reset_cache()
+
+    class Resp:
+        headers = {"Content-Type": "application/json"}
+
+        def json(self):
+            return {"bar": 2}
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(tariffs_mod.requests, "get", lambda *a, **kw: Resp())
+    data = get_tariffs(path=CONFIG)
+    assert data == {"bar": 2}
+
+
+def test_get_tariffs_network_failure(monkeypatch):
+    reset_cache()
+
+    def fake_get(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(tariffs_mod.requests, "get", fake_get)
+    data = get_tariffs(path=CONFIG)
+    assert "clearance_tax_ranges" in data


### PR DESCRIPTION
## Summary
- keep `rate_date` for `to_rub` in CTP duty calculations
- keep `rate_date` for `to_rub` in ETC duty calculations
- document whole-ruble rounding in clearance tax helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abdd3534f0832bb5c4173d30c37a6a