### PR TITLE
Implement basic Russian customs calculator

### DIFF
--- a/tests/test_tks_customs.py
+++ b/tests/test_tks_customs.py
@@ -1,0 +1,21 @@
+import math
+from tks_customs import CustomsCalculator
+
+def test_individual_gasoline_under_3():
+    calc = CustomsCalculator('tks_config.yaml')
+    calc.set_vehicle_data({
+        "age": "1-3",
+        "engine_capacity": 2500,
+        "engine_type": "gasoline",
+        "power": 150,
+        "price": 20000,
+        "currency": "USD",
+        "owner_type": "individual",
+    })
+    result = calc.calculate_tariff()
+    assert result["price_rub"] == 2000000.0
+    assert result["duty"] == 1287375.0
+    assert result["clearance"] == 8530.0
+    assert result["vat"] == 0.0
+    assert result["util_fee"] == 3400.0
+    assert result["total"] == 1299305.0

--- a/tks_config.yaml
+++ b/tks_config.yaml
@@ -1,0 +1,26 @@
+currency_rates:
+  USD: 100.0
+  EUR: 110.0
+  RUB: 1.0
+fixed_rates:
+  under_3:
+    gasoline:
+      rate_per_cc: 514.95
+    diesel:
+      rate_per_cc: 514.95
+    electric:
+      rate_per_cc: 0
+    hybrid:
+      rate_per_cc: 514.95
+clearance_fee_ranges:
+  - [200000, 775]
+  - [450000, 1550]
+  - [1200000, 3100]
+  - [2700000, 8530]
+  - [4200000, 12000]
+  - [5500000, 15500]
+  - [7000000, 20000]
+  - [8000000, 23000]
+  - [9000000, 25000]
+  - [10000000, 27000]
+  - [999999999999, 30000]

--- a/tks_customs.py
+++ b/tks_customs.py
@@ -1,0 +1,57 @@
+import yaml
+from typing import Dict, Any
+
+
+class CustomsCalculator:
+    """Simple customs calculator using fixed rates from config."""
+
+    def __init__(self, config_path: str):
+        with open(config_path, 'r', encoding='utf-8') as f:
+            self.config = yaml.safe_load(f)
+        self.vehicle_data: Dict[str, Any] = {}
+
+    def set_vehicle_data(self, data: Dict[str, Any]) -> "CustomsCalculator":
+        self.vehicle_data = data
+        return self
+
+    # internal helpers
+    def _price_in_rub(self) -> float:
+        price = self.vehicle_data['price']
+        currency = self.vehicle_data['currency'].upper()
+        rate = self.config['currency_rates'][currency]
+        return price * rate
+
+    def _duty(self) -> float:
+        age = self.vehicle_data['age']
+        engine_type = self.vehicle_data['engine_type']
+        capacity = self.vehicle_data['engine_capacity']
+        age_key = 'under_3' if age in ('new', '1-3') else age
+        rate = self.config['fixed_rates'][age_key][engine_type]['rate_per_cc']
+        return rate * capacity
+
+    def _clearance_fee(self, price_rub: float) -> float:
+        for limit, fee in self.config['clearance_fee_ranges']:
+            if price_rub <= limit:
+                return fee
+        return self.config['clearance_fee_ranges'][-1][1]
+
+    def calculate_tariff(self) -> Dict[str, float]:
+        price_rub = float(self._price_in_rub())
+        duty = float(self._duty())
+        clearance = float(self._clearance_fee(price_rub))
+        owner_type = self.vehicle_data.get('owner_type', 'individual')
+        if owner_type == 'individual':
+            vat = 0.0
+            util_fee = 3400.0
+        else:
+            vat = 0.2 * (price_rub + duty + clearance)
+            util_fee = 0.0
+        total = duty + clearance + vat + util_fee
+        return {
+            'price_rub': price_rub,
+            'duty': duty,
+            'clearance': clearance,
+            'vat': vat,
+            'util_fee': util_fee,
+            'total': total,
+        }


### PR DESCRIPTION
## Summary
- add `CustomsCalculator` module with per-cc duty, clearance fee, VAT and recycling fee logic
- provide YAML config and tests for tariff calculation example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0daec6e4832b9e3e0058b481e937