### PR TITLE
Align tariffs config with reference values

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ tariffs:
   base_clearance_fee: 3100
   base_util_fee: 20000
   ctp_util_coeff_base: 1.2
-  etc_util_coeff_base: 1.5
+  etc_util_coeff_base: 1.0
   excise_rates:
     gasoline: 58
     diesel: 58
@@ -23,9 +23,9 @@ tariffs:
   recycling_factors:
     default:
       gasoline: 1.0
-      diesel: 1.1
+      diesel: 1.0
       electric: 0.3
-      hybrid: 0.9
+      hybrid: 1.0
     adjustments:
       "5-7":
         gasoline: 0.26

--- a/tests/test_customs_unified.py
+++ b/tests/test_customs_unified.py
@@ -44,9 +44,9 @@ def test_calculate_etc():
         "excise_rub": 0.0,
         "vat_rub": 0.0,
         "clearance_rub": 3_100,
-        "util_rub": 30_000.0,
+        "util_rub": 20_000.0,
         "recycling_rub": 5_200.0,
-        "total_rub": 1_094_300.0,
+        "total_rub": 1_084_300.0,
     }
 
 


### PR DESCRIPTION
## Summary
- set ETC util coefficient to 1.0
- correct recycling defaults for diesel and hybrid engines
- update ETC unit test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac12d87bd8832bb665881640d98eb8