### PR TITLE
Refactor navigation checks and async services

### DIFF
--- a/bot_alista/bot.py
+++ b/bot_alista/bot.py
@@ -2,10 +2,23 @@ import asyncio
 from aiogram import Bot, Dispatcher
 from bot_alista.settings import settings
 from bot_alista.handlers import menu, calculate, cancel, menu_navigation, request, faq
+from bot_alista.services.rates import init_rates_session, close_rates_session
+
+
+async def on_startup(_):
+    await init_rates_session()
+
+
+async def on_shutdown(_):
+    await close_rates_session()
+
 
 async def main():
     bot = Bot(token=settings.BOT_TOKEN)
     dp = Dispatcher()
+
+    dp.startup.register(on_startup)
+    dp.shutdown.register(on_shutdown)
 
     dp.include_router(menu.router)
     dp.include_router(calculate.router)
@@ -15,6 +28,7 @@ async def main():
     dp.include_router(faq.router)
 
     await dp.start_polling(bot)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -32,8 +32,6 @@ from bot_alista.constants import (
     PROMPT_AGE_OVER3,
     BTN_AGE_OVER3_YES,
     BTN_AGE_OVER3_NO,
-    BTN_BACK,
-    BTN_MAIN_MENU,
     BTN_FAQ,
     BTN_CALC,
     ERROR_RATE,
@@ -45,6 +43,7 @@ from bot_alista.services.rates import (
 )
 from bot_alista.formatting import format_result_message
 from bot_alista.services.customs_calculator import CustomsCalculator
+from bot_alista.services.tariffs import get_tariffs_async
 from .calc_ui import (person_type_kb, usage_type_kb, car_type_kb, currency_kb, age_over3_kb)
 from bot_alista.rules.age import compute_actual_age_years
 from bot_alista.handlers.faq import show_faq
@@ -59,6 +58,21 @@ CAR_TYPE_MAP = {
     "Гибрид": "hybrid",
     "Электро": "electric",
 }
+
+
+async def _handle_faq_and_nav(
+    message: types.Message, state: FSMContext, nav: NavigationManager | None
+) -> bool:
+    """Handle FAQ requests and navigation commands.
+
+    Returns ``True`` if the caller should exit early.
+    """
+    if message.text == BTN_FAQ:
+        await show_faq(message, state)
+        return True
+    if nav and await nav.handle_nav(message, state):
+        return True
+    return False
 
 # ---------------------------------------------------------------------------
 # Conversation steps
@@ -85,10 +99,7 @@ async def customs_command(message: types.Message, state: FSMContext) -> None:
 async def get_person_type(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     if message.text not in {"Физическое лицо", "Юридическое лицо"}:
         await message.answer(ERROR_PERSON)
@@ -105,10 +116,7 @@ async def get_person_type(message: types.Message, state: FSMContext) -> None:
 async def get_usage_type(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     if message.text not in {"Личное", "Коммерческое"}:
         await message.answer(ERROR_USAGE)
@@ -125,10 +133,7 @@ async def get_usage_type(message: types.Message, state: FSMContext) -> None:
 async def get_car_type(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     if message.text not in {"Бензин", "Дизель", "Гибрид", "Электро"}:
         await message.answer(ERROR_TYPE)
@@ -149,10 +154,7 @@ async def get_car_type(message: types.Message, state: FSMContext) -> None:
 async def choose_currency(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     if message.text not in CURRENCY_CODES:
         await message.answer(ERROR_CURRENCY)
@@ -169,10 +171,7 @@ async def choose_currency(message: types.Message, state: FSMContext) -> None:
 async def get_amount(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     try:
         amount = float(message.text.replace(",", "."))
@@ -199,10 +198,7 @@ async def get_amount(message: types.Message, state: FSMContext) -> None:
 async def get_engine(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     try:
         engine = int(message.text)
@@ -221,10 +217,7 @@ async def get_engine(message: types.Message, state: FSMContext) -> None:
 async def get_power(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     try:
         val = message.text.lower().replace(",", ".")
@@ -248,10 +241,7 @@ async def get_power(message: types.Message, state: FSMContext) -> None:
 async def get_year(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     try:
         year = int(message.text)
@@ -272,10 +262,7 @@ async def get_year(message: types.Message, state: FSMContext) -> None:
 async def handle_age_over3(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     if message.text not in {BTN_AGE_OVER3_YES, BTN_AGE_OVER3_NO}:
         await message.answer(PROMPT_AGE_OVER3, reply_markup=age_over3_kb())
@@ -294,10 +281,7 @@ async def handle_age_over3(message: types.Message, state: FSMContext) -> None:
 async def get_manual_rate(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
     nav: NavigationManager | None = data.get("_nav")
-    if message.text == BTN_FAQ:
-        await show_faq(message, state)
-        return
-    if nav and await nav.handle_nav(message, state):
+    if await _handle_faq_and_nav(message, state, nav):
         return
     code = data.get("pending_rate_code")
     try:
@@ -373,8 +357,8 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             age_group = "5-7"
         else:
             age_group = "over_7"
-
-        calc = CustomsCalculator()
+        tariffs = await get_tariffs_async()
+        calc = CustomsCalculator(tariffs=tariffs)
         calc.tariffs.setdefault("ctp", {"duty_rate": 0.2, "min_per_cc_eur": 0.44})
         calc.set_vehicle_details(
             age=age_group,

--- a/bot_alista/handlers/request.py
+++ b/bot_alista/handlers/request.py
@@ -2,7 +2,7 @@ from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 from bot_alista.states import RequestStates
 from bot_alista.keyboards.navigation import back_menu
-from bot_alista.services.email import send_email
+from bot_alista.services.email import send_email_async
 from bot_alista.services.pdf_report import generate_request_pdf
 from bot_alista.utils.reset import reset_to_menu
 from bot_alista.settings import settings
@@ -21,7 +21,6 @@ from bot_alista.constants import (
 from bot_alista.handlers.faq import show_faq
 from bot_alista.utils.navigation import NavigationManager, NavStep
 
-import asyncio
 import os
 import uuid
 
@@ -147,8 +146,7 @@ async def get_comment(message: types.Message, state: FSMContext):
     generate_request_pdf(data, pdf_path)
 
     # Отправляем на e-mail менеджера
-    email_sent = await asyncio.to_thread(
-        send_email,
+    email_sent = await send_email_async(
         settings.EMAIL_TO,
         "Заявка на растаможку",
         email_body,

--- a/bot_alista/main.py
+++ b/bot_alista/main.py
@@ -2,8 +2,11 @@
 
 import asyncio
 import logging
+import os
 
-logging.basicConfig(level=logging.INFO)
+level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+level = getattr(logging, level_name, logging.INFO)
+logging.basicConfig(level=level)
 
 from bot_alista.bot import main as run_bot
 

--- a/bot_alista/services/email.py
+++ b/bot_alista/services/email.py
@@ -2,6 +2,7 @@ import os
 import smtplib
 import ssl
 import logging
+import asyncio
 
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
@@ -52,5 +53,14 @@ def send_email(
     except Exception as e:  # pragma: no cover - мы только логируем и возвращаем
         logger.error("Ошибка отправки письма: %s", e)
         return False
+
+
+async def send_email_async(
+    to_email: str, subject: str, body: str, attachment_path: str | None = None
+) -> bool:
+    """Asynchronously send an email using a background thread."""
+    return await asyncio.to_thread(
+        send_email, to_email, subject, body, attachment_path
+    )
 
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,73 @@
+import pytest
+from aiogram import types
+
+from bot_alista.utils.navigation import NavigationManager, NavStep
+from bot_alista.utils.reset import reset_to_menu
+from bot_alista.states import CalculationStates
+from bot_alista.constants import BTN_BACK, BTN_MAIN_MENU
+
+
+class DummyMessage:
+    def __init__(self, text: str = "") -> None:
+        self.text = text
+        self.answers: list[tuple[str, object]] = []
+
+    async def answer(self, text: str, reply_markup=None, **kwargs):
+        self.answers.append((text, reply_markup))
+
+
+class DummyFSM:
+    def __init__(self) -> None:
+        self.state = None
+        self.cleared = False
+
+    async def set_state(self, state):
+        self.state = state
+
+    async def clear(self):
+        self.cleared = True
+
+
+@pytest.mark.asyncio
+async def test_nav_push():
+    nav = NavigationManager(total_steps=1)
+    msg = DummyMessage()
+    fsm = DummyFSM()
+    kb = types.ReplyKeyboardMarkup(keyboard=[])
+    step = NavStep(CalculationStates.person_type, "Prompt", kb)
+    await nav.push(msg, fsm, step)
+    assert fsm.state == CalculationStates.person_type
+    assert msg.answers[0][0] == "Шаг 1/1: Prompt"
+    assert msg.answers[0][1] is kb
+
+
+@pytest.mark.asyncio
+async def test_handle_nav_back_and_main_menu():
+    nav = NavigationManager(total_steps=2)
+    msg = DummyMessage()
+    fsm = DummyFSM()
+    kb = types.ReplyKeyboardMarkup(keyboard=[])
+    await nav.push(msg, fsm, NavStep(CalculationStates.person_type, "P1", kb))
+    await nav.push(msg, fsm, NavStep(CalculationStates.usage_type, "P2", kb))
+
+    back_msg = DummyMessage(BTN_BACK)
+    handled = await nav.handle_nav(back_msg, fsm)
+    assert handled is True
+    assert fsm.state == CalculationStates.person_type
+    assert back_msg.answers[0][0].startswith("Шаг 1/2")
+
+    main_msg = DummyMessage(BTN_MAIN_MENU)
+    handled = await nav.handle_nav(main_msg, fsm)
+    assert handled is True
+    assert fsm.cleared is True
+    assert nav.stack == []
+    assert main_msg.answers[0][0].startswith(BTN_MAIN_MENU)
+
+
+@pytest.mark.asyncio
+async def test_reset_to_menu():
+    msg = DummyMessage()
+    fsm = DummyFSM()
+    await reset_to_menu(msg, fsm)
+    assert fsm.cleared is True
+    assert msg.answers[0][0].startswith(BTN_MAIN_MENU)


### PR DESCRIPTION
## Summary
- Consolidate FAQ/back-navigation handling into a helper
- Introduce async tariff fetching and shared rate session
- Offload email sending and make logging configurable
- Add tests for tariff retrieval and navigation utilities

## Testing
- ⚠️ `python3 -m pytest -q` *(missing pytest in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1e983d38832bb114845fb6263eae