### PR TITLE
Add method type keyboard import for calculation flow

### DIFF
--- a/bot_alista/handlers/calc_ui.py
+++ b/bot_alista/handlers/calc_ui.py
@@ -78,4 +78,5 @@ __all__ = [
     "car_type_kb",
     "currency_kb",
     "age_over3_kb",
+    "method_type_kb",
 ]

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -47,7 +47,14 @@ from bot_alista.services.rates import (
 from bot_alista.formatting import format_result_message
 from bot_alista.services.customs_calculator import CustomsCalculator
 from bot_alista.services.tariffs import get_tariffs_async
-from .calc_ui import (person_type_kb, usage_type_kb, car_type_kb, currency_kb, age_over3_kb)
+from .calc_ui import (
+    person_type_kb,
+    usage_type_kb,
+    car_type_kb,
+    currency_kb,
+    age_over3_kb,
+    method_type_kb,
+)
 from bot_alista.rules.age import compute_actual_age_years
 from bot_alista.handlers.faq import show_faq
 


### PR DESCRIPTION
## Summary
- Import `method_type_kb` in calculation handler and export in UI module
- Enable method selection when starting calculation flow

## Testing
- `python - <<'PY'
import asyncio
from bot_alista.handlers import calculate
from bot_alista.constants import BTN_CALC

class FakeState:
    def __init__(self):
        self.data={}
    async def update_data(self, **kwargs):
        self.data.update(kwargs)
    async def get_data(self):
        return self.data
    async def set_state(self, state):
        self.state = state

class FakeMessage:
    text = BTN_CALC
    async def answer(self, *args, **kwargs):
        print('answer', args, kwargs)

async def main():
    state=FakeState()
    msg=FakeMessage()
    await calculate.start_calculation(msg,state)
    print('state keys', list(state.data.keys()))

asyncio.run(main())
PY`
- `pytest` *(fails: async def functions are not natively supported)*
- `pip install pytest-asyncio` *(fails: Could not find a version that satisfies the requirement pytest-asyncio (Tunnel connection failed: 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68ac34cf97a0832b8cdc91912ed1001f