### PR TITLE
Refactor customs calculations with Decimal and enum mappings

### DIFF
--- a/bot_alista/formatting.py
+++ b/bot_alista/formatting.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Dict, Any, Union
+from decimal import Decimal
+
+Number = Union[float, Decimal]
 
 
-def _fmt_money_rub(v: float) -> str:
-    """
-    Format RUB with thin spaces and 2 decimals.
-    """
-    s = f"{v:,.2f}"
+def _fmt_money_rub(v: Number) -> str:
+    """Format RUB with thin spaces and 2 decimals."""
+    s = f"{float(v):,.2f}"
     return s.replace(",", " ").replace(".00", "") + " ₽"
 
 
-def _fmt_money_generic(v: float, suffix: str) -> str:
-    s = f"{v:,.2f}"
+def _fmt_money_generic(v: Number, suffix: str) -> str:
+    s = f"{float(v):,.2f}"
     s = s.replace(",", " ")
     if suffix:
         return f"{s} {suffix}"
@@ -26,7 +27,7 @@ def format_result_message(
     rates: Dict[str, float],
     meta: Dict[str, Any],
     core: Dict[str, Any],
-    util_fee_rub: float,
+    util_fee_rub: Number,
 ) -> str:
     """
     Build a user-friendly Telegram message with emojis and clear sections.
@@ -45,9 +46,7 @@ def format_result_message(
     br = core["breakdown"]
     total_no_util = br["total_rub"]
     util_fee_rub = br.get("util_rub", util_fee_rub)
-    total_with_util = br.get(
-        "total_with_util_rub", round(total_no_util + util_fee_rub, 2)
-    )
+    total_with_util = br.get("total_with_util_rub", total_no_util + util_fee_rub)
 
     usd_rate = rates.get("USD")
     eur_rate = rates.get("EUR")

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,6 +1,8 @@
 import pytest
 from aiogram import types
 
+import asyncio
+
 from bot_alista.utils.navigation import NavigationManager, NavStep
 from bot_alista.utils.reset import reset_to_menu
 from bot_alista.states import CalculationStates
@@ -28,46 +30,52 @@ class DummyFSM:
         self.cleared = True
 
 
-@pytest.mark.asyncio
-async def test_nav_push():
-    nav = NavigationManager(total_steps=1)
-    msg = DummyMessage()
-    fsm = DummyFSM()
-    kb = types.ReplyKeyboardMarkup(keyboard=[])
-    step = NavStep(CalculationStates.person_type, "Prompt", kb)
-    await nav.push(msg, fsm, step)
-    assert fsm.state == CalculationStates.person_type
-    assert msg.answers[0][0] == "Шаг 1/1: Prompt"
-    assert msg.answers[0][1] is kb
+def test_nav_push():
+    async def scenario():
+        nav = NavigationManager(total_steps=1)
+        msg = DummyMessage()
+        fsm = DummyFSM()
+        kb = types.ReplyKeyboardMarkup(keyboard=[])
+        step = NavStep(CalculationStates.person_type, "Prompt", kb)
+        await nav.push(msg, fsm, step)
+        assert fsm.state == CalculationStates.person_type
+        assert msg.answers[0][0] == "Шаг 1/1: Prompt"
+        assert msg.answers[0][1] is kb
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_handle_nav_back_and_main_menu():
-    nav = NavigationManager(total_steps=2)
-    msg = DummyMessage()
-    fsm = DummyFSM()
-    kb = types.ReplyKeyboardMarkup(keyboard=[])
-    await nav.push(msg, fsm, NavStep(CalculationStates.person_type, "P1", kb))
-    await nav.push(msg, fsm, NavStep(CalculationStates.usage_type, "P2", kb))
+def test_handle_nav_back_and_main_menu():
+    async def scenario():
+        nav = NavigationManager(total_steps=2)
+        msg = DummyMessage()
+        fsm = DummyFSM()
+        kb = types.ReplyKeyboardMarkup(keyboard=[])
+        await nav.push(msg, fsm, NavStep(CalculationStates.person_type, "P1", kb))
+        await nav.push(msg, fsm, NavStep(CalculationStates.usage_type, "P2", kb))
 
-    back_msg = DummyMessage(BTN_BACK)
-    handled = await nav.handle_nav(back_msg, fsm)
-    assert handled is True
-    assert fsm.state == CalculationStates.person_type
-    assert back_msg.answers[0][0].startswith("Шаг 1/2")
+        back_msg = DummyMessage(BTN_BACK)
+        handled = await nav.handle_nav(back_msg, fsm)
+        assert handled is True
+        assert fsm.state == CalculationStates.person_type
+        assert back_msg.answers[0][0].startswith("Шаг 1/2")
 
-    main_msg = DummyMessage(BTN_MAIN_MENU)
-    handled = await nav.handle_nav(main_msg, fsm)
-    assert handled is True
-    assert fsm.cleared is True
-    assert nav.stack == []
-    assert main_msg.answers[0][0].startswith(BTN_MAIN_MENU)
+        main_msg = DummyMessage(BTN_MAIN_MENU)
+        handled = await nav.handle_nav(main_msg, fsm)
+        assert handled is True
+        assert fsm.cleared is True
+        assert nav.stack == []
+        assert main_msg.answers[0][0].startswith(BTN_MAIN_MENU)
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_reset_to_menu():
-    msg = DummyMessage()
-    fsm = DummyFSM()
-    await reset_to_menu(msg, fsm)
-    assert fsm.cleared is True
-    assert msg.answers[0][0].startswith(BTN_MAIN_MENU)
+def test_reset_to_menu():
+    async def scenario():
+        msg = DummyMessage()
+        fsm = DummyFSM()
+        await reset_to_menu(msg, fsm)
+        assert fsm.cleared is True
+        assert msg.answers[0][0].startswith(BTN_MAIN_MENU)
+
+    asyncio.run(scenario())

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -19,8 +19,12 @@ def test_get_cached_rates_partial(monkeypatch, tmp_path):
         mapping = {"USD": 1.0, "EUR": 2.0, "JPY": 3.0, "CNY": 4.0}
         return {code: mapping[code] for code in codes}
 
-    monkeypatch.setattr(rates, "_fetch_cbr_rates", fake_fetch)
-    monkeypatch.setattr(rates, "_cache_file", lambda d: tmp_path / f"{d.isoformat()}.json")
+    monkeypatch.setattr(rates._rates_client, "fetch", fake_fetch)
+    monkeypatch.setattr(
+        rates._rates_client,
+        "_cache_file",
+        lambda d: tmp_path / f"{d.isoformat()}.json",
+    )
 
     day = date(2024, 1, 1)
 

--- a/tests/test_tariffs.py
+++ b/tests/test_tariffs.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -20,112 +21,128 @@ def reset_cache():
     tariffs_mod._cache_date = None
 
 
-@pytest.mark.asyncio
-async def test_get_tariffs_env_override(monkeypatch):
-    reset_cache()
-    monkeypatch.setenv(
-        "CUSTOMS_TARIFF_DATA", "clearance_tax_ranges: []\nvehicle_types: {}"
-    )
-    data = await get_tariffs_async(path=CONFIG)
-    assert data["clearance_tax_ranges"] == []
-    monkeypatch.delenv("CUSTOMS_TARIFF_DATA")
+def test_get_tariffs_env_override(monkeypatch):
+    async def scenario():
+        reset_cache()
+        monkeypatch.setenv(
+            "CUSTOMS_TARIFF_DATA", "clearance_tax_ranges: []\nvehicle_types: {}"
+        )
+        data = await get_tariffs_async(path=CONFIG)
+        assert data["clearance_tax_ranges"] == []
+        monkeypatch.delenv("CUSTOMS_TARIFF_DATA")
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_get_tariffs_env_override_invalid(monkeypatch):
-    reset_cache()
-    monkeypatch.setenv("CUSTOMS_TARIFF_DATA", "foo: 1")
-    with pytest.raises(ValueError):
-        await get_tariffs_async(path=CONFIG)
-    monkeypatch.delenv("CUSTOMS_TARIFF_DATA")
+def test_get_tariffs_env_override_invalid(monkeypatch):
+    async def scenario():
+        reset_cache()
+        monkeypatch.setenv("CUSTOMS_TARIFF_DATA", "foo: 1")
+        with pytest.raises(ValueError):
+            await get_tariffs_async(path=CONFIG)
+        monkeypatch.delenv("CUSTOMS_TARIFF_DATA")
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_get_tariffs_network_success(monkeypatch):
-    reset_cache()
+def test_get_tariffs_network_success(monkeypatch):
+    async def scenario():
+        reset_cache()
 
-    class Resp:
-        headers = {"Content-Type": "application/json"}
+        class Resp:
+            headers = {"Content-Type": "application/json"}
 
-        async def json(self):
-            return {"clearance_tax_ranges": [], "vehicle_types": {}}
+            async def json(self):
+                return {"clearance_tax_ranges": [], "vehicle_types": {}}
 
-        def raise_for_status(self):
+            def raise_for_status(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, *args, **kwargs):
+                return Resp()
+
+        monkeypatch.setattr(
+            tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session()
+        )
+        data = await get_tariffs_async(path=CONFIG)
+        assert data == {"clearance_tax_ranges": [], "vehicle_types": {}}
+
+    asyncio.run(scenario())
+
+
+def test_get_tariffs_network_invalid(monkeypatch):
+    async def scenario():
+        reset_cache()
+
+        class Resp:
+            headers = {"Content-Type": "application/json"}
+
+            async def json(self):
+                return {"foo": 1}
+
+            def raise_for_status(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, *args, **kwargs):
+                return Resp()
+
+        monkeypatch.setattr(
+            tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session()
+        )
+        data = await get_tariffs_async(path=CONFIG)
+        assert "clearance_tax_ranges" in data
+
+    asyncio.run(scenario())
+
+
+def test_get_tariffs_network_failure(monkeypatch):
+    async def scenario():
+        reset_cache()
+
+        class Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        async def fake_sleep(_):
             pass
 
-        async def __aenter__(self):
-            return self
+        monkeypatch.setattr(
+            tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session()
+        )
+        monkeypatch.setattr(tariffs_mod.asyncio, "sleep", fake_sleep)
+        data = await get_tariffs_async(path=CONFIG)
+        assert "clearance_tax_ranges" in data
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class Session:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        def get(self, *args, **kwargs):
-            return Resp()
-
-    monkeypatch.setattr(tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session())
-    data = await get_tariffs_async(path=CONFIG)
-    assert data == {"clearance_tax_ranges": [], "vehicle_types": {}}
-
-
-@pytest.mark.asyncio
-async def test_get_tariffs_network_invalid(monkeypatch):
-    reset_cache()
-
-    class Resp:
-        headers = {"Content-Type": "application/json"}
-
-        async def json(self):
-            return {"foo": 1}
-
-        def raise_for_status(self):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class Session:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        def get(self, *args, **kwargs):
-            return Resp()
-
-    monkeypatch.setattr(tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session())
-    data = await get_tariffs_async(path=CONFIG)
-    assert "clearance_tax_ranges" in data
-
-
-@pytest.mark.asyncio
-async def test_get_tariffs_network_failure(monkeypatch):
-    reset_cache()
-
-    class Session:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        def get(self, *args, **kwargs):
-            raise RuntimeError("boom")
-
-    async def fake_sleep(_):
-        pass
-
-    monkeypatch.setattr(tariffs_mod.aiohttp, "ClientSession", lambda *a, **kw: Session())
-    monkeypatch.setattr(tariffs_mod.asyncio, "sleep", fake_sleep)
-    data = await get_tariffs_async(path=CONFIG)
-    assert "clearance_tax_ranges" in data
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- map fuel labels to EngineType and derive age buckets via `compute_actual_age_years`
- switch customs math to `Decimal`, add pure mode helpers and simplify `calculate_auto`
- replace global rate helpers with `RatesClient`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad495a0304832bb27a3c6579ab3c8f