### PR TITLE
Improve PDF unicode sanitization and tests

### DIFF
--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -10,6 +10,7 @@ if str(SERVICE_ROOT) not in sys.path:
 
 pdf_report = pytest.importorskip("services.pdf_report")
 generate_calculation_pdf = pdf_report.generate_calculation_pdf
+generate_request_pdf = pdf_report.generate_request_pdf
 
 
 def test_generate_calculation_pdf_handles_missing_fields(tmp_path):
@@ -20,10 +21,31 @@ def test_generate_calculation_pdf_handles_missing_fields(tmp_path):
     assert filename.exists() and filename.stat().st_size > 0
 
 
+def test_generate_calculation_pdf_accepts_cyrillic(tmp_path):
+    result = {"total_eur": 100, "eur_rate": 90}
+    user_info = {"car_type": "бензин"}
+    filename = tmp_path / "cyrillic.pdf"
+    generate_calculation_pdf(result, user_info, str(filename))
+    assert filename.exists() and filename.stat().st_size > 0
+
+
 def test_generate_calculation_pdf_ignores_emojis(tmp_path):
     """PDF generation should succeed even if text contains emoji."""
     result = {"total_eur": 100, "eur_rate": 90}
     user_info = {"car_type": "gasoline 🚗"}
     filename = tmp_path / "emoji.pdf"
     generate_calculation_pdf(result, user_info, str(filename))
+    assert filename.exists() and filename.stat().st_size > 0
+
+
+def test_generate_request_pdf_strips_problematic_symbols(tmp_path):
+    data = {
+        "name": "Иван 🚀",
+        "car": "Лада™",
+        "contact": "test@example.com",
+        "price": "1000",
+        "comment": "Примечание с эмодзи 😎 и нотами 𝄞",
+    }
+    filename = tmp_path / "symbols.pdf"
+    generate_request_pdf(data, str(filename))
     assert filename.exists() and filename.stat().st_size > 0


### PR DESCRIPTION
## Summary
- broaden text sanitization to drop unsupported or control characters
- automatically sanitize all PDF cell output
- cover Cyrillic, emoji, and exotic symbols in PDF tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad56578044832bb2b0581425f43240