### PR TITLE
Refactor customs calculator to follow new tariff schema

### DIFF
--- a/tests/test_customs_calculator.py
+++ b/tests/test_customs_calculator.py
@@ -1,51 +1,26 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from bot_alista.services.customs_calculator import CustomsCalculator, WrongParamException
-import yaml
+
+CONFIG_PATH = ROOT / "external/tks_api_official/config.yaml"
 
 
-def _make_calc(config_path):
-    return CustomsCalculator(str(config_path))
+def _make_calc():
+    return CustomsCalculator(str(CONFIG_PATH))
 
 
-import pytest
-
-
-@pytest.fixture
-def config_file(tmp_path):
-    data = {
-        'tariffs': {
-            'age_groups': {
-                'overrides': {
-                    '5-7': {
-                        'gasoline': {'rate_per_cc': 1.0}
-                    }
-                }
-            },
-            'base_clearance_fee': 1000,
-            'base_util_fee': 500,
-            'ctp_util_coeff_base': 1.0,
-            'recycling_factors': {
-                'default': {'gasoline': 1.0},
-                'adjustments': {}
-            },
-            'excise_rates': {'gasoline': 0.0}
-        }
-    }
-    path = tmp_path / "config.yaml"
-    path.write_text(yaml.dump(data))
-    return path
-
-
-def test_calculate_etc_and_ctp(config_file):
-    calc = _make_calc(config_file)
+@pytest.mark.parametrize("age", ["1-3", "5-7"])
+def test_calculate_etc_and_ctp(age):
+    calc = _make_calc()
     calc.set_vehicle_details(
-        age="5-7",
+        age=age,
         engine_capacity=2000,
         engine_type="gasoline",
         power=150,
@@ -62,8 +37,8 @@ def test_calculate_etc_and_ctp(config_file):
     assert ctp["Total Pay (RUB)"] > 0
 
 
-def test_calculate_auto_returns_one_of_methods(config_file):
-    calc = _make_calc(config_file)
+def test_calculate_auto_returns_one_of_methods():
+    calc = _make_calc()
     calc.set_vehicle_details(
         age="5-7",
         engine_capacity=2000,
@@ -79,8 +54,8 @@ def test_calculate_auto_returns_one_of_methods(config_file):
     assert auto["Total Pay (RUB)"] > 0
 
 
-def test_convert_to_local_currency_error(config_file):
-    calc = _make_calc(config_file)
+def test_convert_to_local_currency_error():
+    calc = _make_calc()
 
     def bad_convert(amount, currency, target):
         raise ValueError("fail")
@@ -90,8 +65,8 @@ def test_convert_to_local_currency_error(config_file):
         calc.convert_to_local_currency(1, "EUR")
 
 
-def test_calculate_methods_propagate_conversion_error(config_file):
-    calc = _make_calc(config_file)
+def test_calculate_methods_propagate_conversion_error():
+    calc = _make_calc()
     calc.set_vehicle_details(
         age="5-7",
         engine_capacity=2000,
@@ -114,3 +89,4 @@ def test_calculate_methods_propagate_conversion_error(config_file):
     with pytest.raises(WrongParamException) as exc:
         calc.calculate_ctp()
     assert "CTP" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- refactor customs calculator to pull tariffs from new `vehicle_types` configuration and compute util, clearance and recycling fees
- add vehicle type option and clear error messages for missing tariff data
- expand customs calculator tests with regression coverage for vehicles ≤3 and >3 years

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad821b77f8832bb66f910eced5e715