### PR TITLE
feat: support preferential rates and util cost inputs

### DIFF
--- a/bot_alista/formatting.py
+++ b/bot_alista/formatting.py
@@ -28,6 +28,9 @@ def format_result_message(
     meta: Dict[str, Any],
     core: Dict[str, Any],
     util_fee_rub: Number,
+    country_origin: str | None = None,
+    avg_vehicle_cost_rub: Number | None = None,
+    actual_costs_rub: Number | None = None,
 ) -> str:
     """
     Build a user-friendly Telegram message with emojis and clear sections.
@@ -64,6 +67,8 @@ def format_result_message(
         lines.append(f"💱 Курс USD: {_fmt_money_generic(usd_rate, '₽')}")
     if eur_rate is not None:
         lines.append(f"💱 Курс EUR: {_fmt_money_generic(eur_rate, '₽')}")
+    if country_origin:
+        lines.append(f"🌍 Страна происхождения: {country_origin}")
     lines.append(f"💰 Таможенная стоимость: {_fmt_money_rub(br['customs_value_rub'])}\n")
 
     lines.append(f"🛃 Пошлина: {_fmt_money_rub(br['duty_rub'])}")
@@ -86,6 +91,14 @@ def format_result_message(
         lines.append(f"• {age_info}")
     if duty_rate_info:
         lines.append(f"• Ставка пошлины: {duty_rate_info}")
+    if avg_vehicle_cost_rub is not None:
+        lines.append(
+            f"• Средняя стоимость (РС): {_fmt_money_rub(avg_vehicle_cost_rub)}"
+        )
+    if actual_costs_rub is not None:
+        lines.append(
+            f"• Фактические затраты (СЗ): {_fmt_money_rub(actual_costs_rub)}"
+        )
     for n in extra_notes:
         lines.append(f"• {n}")
 

--- a/bot_alista/handlers/calculate.py
+++ b/bot_alista/handlers/calculate.py
@@ -436,6 +436,10 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             "extra_notes": core.get("notes", []),
         }
 
+        country_origin = data.get("country_origin")
+        avg_vehicle_cost_rub = data.get("avg_vehicle_cost_rub")
+        actual_costs_rub = data.get("actual_costs_rub")
+
         msg = format_result_message(
             currency_code=currency_code,
             price_amount=amount,
@@ -443,6 +447,9 @@ async def _run_calculation(state: FSMContext, message: types.Message) -> None:
             meta=meta,
             core=core,
             util_fee_rub=core["breakdown"].get("util_rub", 0.0),
+            country_origin=country_origin,
+            avg_vehicle_cost_rub=avg_vehicle_cost_rub,
+            actual_costs_rub=actual_costs_rub,
         )
         await message.answer(
             msg,


### PR DESCRIPTION
## Summary
- allow country-origin preferences and cost data in tariff calculations
- propagate origin and cost info through formatting and handlers
- test preferential duty rates and utilization fee cost params

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad85a9ad1c832b961ad8cb4101e69f