### PR TITLE
Improve tariff validation, navigation, and caching

### DIFF
--- a/bot_alista/keyboards/calc.py
+++ b/bot_alista/keyboards/calc.py
@@ -1,0 +1,34 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+from bot_alista.keyboards.navigation import back_menu
+
+
+def _build(options: list[str]) -> ReplyKeyboardMarkup:
+    keyboard = [[KeyboardButton(text=o) for o in options]]
+    keyboard.extend(back_menu().keyboard)
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def age_keyboard() -> ReplyKeyboardMarkup:
+    return _build(["new", "1-3", "3-5", "5-7", "over_7"])
+
+
+def engine_keyboard() -> ReplyKeyboardMarkup:
+    return _build(["gasoline", "diesel", "electric", "hybrid"])
+
+
+def owner_keyboard() -> ReplyKeyboardMarkup:
+    return _build(["individual", "company"])
+
+
+def currency_keyboard() -> ReplyKeyboardMarkup:
+    return _build(["USD", "EUR"])
+
+
+__all__ = [
+    "age_keyboard",
+    "engine_keyboard",
+    "owner_keyboard",
+    "currency_keyboard",
+]
+

--- a/bot_alista/services/rates.py
+++ b/bot_alista/services/rates.py
@@ -1,14 +1,30 @@
 import asyncio
+import time
 from currency_converter_free import CurrencyConverter
 
 _converter = CurrencyConverter(source="CBR")
+_cache: dict[str, tuple[float, float]] = {}
 
 
-async def get_rates(codes: list[str] | None = None) -> dict[str, float]:
+async def get_rates(
+    codes: list[str] | None = None,
+    ttl: int = 3600,
+    force_refresh: bool = False,
+) -> dict[str, float]:
     codes = codes or ["USD", "EUR"]
+    now = time.time()
     rates: dict[str, float] = {}
     for code in codes:
+        cached = _cache.get(code)
+        if (
+            not force_refresh
+            and cached is not None
+            and now - cached[1] < ttl
+        ):
+            rates[code] = cached[0]
+            continue
         rate = await asyncio.to_thread(_converter.convert, 1, code, "RUB")
+        _cache[code] = (rate, now)
         rates[code] = rate
     return rates
 

--- a/bot_alista/settings.py
+++ b/bot_alista/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     EMAIL_LOGIN: str
     EMAIL_PASSWORD: str
     EMAIL_TO: str
+    LOG_LEVEL: str = Field("INFO", env="LOG_LEVEL")
     tariff_config: Dict[str, Any] = Field(default_factory=dict)
 
     class Config:

--- a/bot_alista/utils/navigation.py
+++ b/bot_alista/utils/navigation.py
@@ -53,3 +53,15 @@ class NavigationManager:
             )
             return True
         return False
+
+
+def with_nav(handler):
+    async def wrapped(message: types.Message, state: FSMContext, *args, **kwargs):
+        data = await state.get_data()
+        nav: NavigationManager | None = data.get("_nav")
+        if nav and await nav.handle_nav(message, state):
+            return
+        return await handler(message, state, nav=nav, *args, **kwargs)
+
+    return wrapped
+


### PR DESCRIPTION
## Summary
- validate tariff configs with a pydantic model and configurable log level
- switch calculation wizard to choice keyboards and shared nav decorator
- cache currency rates with TTL and expand CustomsCalculator tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdb2b5384832bb5c84b5c2845da51